### PR TITLE
w.i.p. starts download log feature

### DIFF
--- a/app/javascript/react/screens/App/Plan/Plan.js
+++ b/app/javascript/react/screens/App/Plan/Plan.js
@@ -111,7 +111,8 @@ class Plan extends React.Component {
       isRejectedPlan,
       isFetchingPlan,
       isQueryingVms,
-      isRejectedVms
+      isRejectedVms,
+      downloadLogAction
     } = this.props;
 
     const {
@@ -148,6 +149,7 @@ class Plan extends React.Component {
               <PlanRequestDetailList
                 planFinished={planFinished}
                 planRequestTasks={planRequestTasksMutable}
+                downloadLogAction={downloadLogAction}
               />
             )}
           {!planNotStarted &&
@@ -202,7 +204,8 @@ Plan.propTypes = {
   queryPlanVmsAction: PropTypes.func,
   isQueryingVms: PropTypes.bool,
   isRejectedVms: PropTypes.bool,
-  resetPlanStateAction: PropTypes.func
+  resetPlanStateAction: PropTypes.func,
+  downloadLogAction: PropTypes.func
 };
 Plan.defaultProps = {
   planName: '',

--- a/app/javascript/react/screens/App/Plan/Plan.scss
+++ b/app/javascript/react/screens/App/Plan/Plan.scss
@@ -1,3 +1,11 @@
+.plan-request-details-list .list-view-pf-main-info {
+  padding: 10px 0;
+}
+
+.plan-request-details-list .list-view-pf-additional-info-item {
+  padding: 10px 0;
+}
+
 .plan-request-details-list .progress-description {
   overflow: visible;
   text-overflow: initial;
@@ -7,22 +15,16 @@
   width: 30%;
 }
 
-.plan-request-details-list .list-view-pf-actions {
-  margin-bottom: 10px;
-  margin-top: 10px;
-}
-
-.plan-request-details-list .list-view-pf-main-info {
-  padding-top: 10px;
-  padding-bottom: 10px;
-}
-
 .plan-request-details-list .utilization-bar-pf {
   min-width: 175px;
 }
 
 .plan-request-details-list .progress-description {
   margin-bottom: 7px;
+}
+
+.plan-request-details-list .progress {
+  margin-bottom: 0px;
 }
 
 .task-info-popover .popover-title {

--- a/app/javascript/react/screens/App/Plan/PlanActions.js
+++ b/app/javascript/react/screens/App/Plan/PlanActions.js
@@ -71,3 +71,7 @@ export const fetchPlanAction = (url, id) => {
 export const resetPlanStateAction = () => ({
   type: RESET_PLAN_STATE
 });
+
+export const downloadLogAction = taskId => {
+  // todo: write download log api logic
+};

--- a/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
@@ -274,6 +274,8 @@ class PlanRequestDetailList extends React.Component {
       pageChangeValue
     } = this.state;
 
+    const { downloadLogAction } = this.props;
+
     const paginatedSortedFiltersTasks = this.filterSortPaginatePlanRequestTasks();
 
     return (
@@ -384,22 +386,6 @@ class PlanRequestDetailList extends React.Component {
                 task.totalDiskSpaceGb
               );
 
-              // const states = [];
-              // if (task.options.progress.states) {
-              //   Object.entries(task.options.progress.states).forEach(
-              //     ([key, value]) => {
-              //       states.push(
-              //         <div key={`key${task.id}`}>
-              //           <small>
-              //             <i>{key}:</i>&nbsp;
-              //             {value.description}
-              //           </small>
-              //         </div>
-              //       );
-              //     }
-              //   );
-              // }
-
               const popoverContent = (
                 <Popover
                   id={`popover${task.id}${n}`}
@@ -434,49 +420,69 @@ class PlanRequestDetailList extends React.Component {
                   heading={task.vmName}
                   additionalInfo={[
                     <ListView.InfoItem
+                      key={`${task.id}-message`}
+                      style={{
+                        flexDirection: 'column',
+                        alignItems: 'flex-start',
+                        marginRight: 80
+                      }}
+                    >
+                      <div>
+                        <span style={{ textTransform: 'capitalize' }}>
+                          {task.message}
+                        </span>
+                        &nbsp;
+                        {/* Todo: revisit FieldLevelHelp props in patternfly-react to support this */}
+                        <OverlayTrigger
+                          rootClose
+                          trigger="click"
+                          placement="left"
+                          overlay={popoverContent}
+                        >
+                          <Button bsStyle="link">
+                            <Icon type="pf" name="info" />
+                          </Button>
+                        </OverlayTrigger>
+                      </div>
+                      <div>
+                        <ListView.Icon type="fa" size="lg" name="clock-o" />
+                        {elapsedTime}
+                      </div>
+                    </ListView.InfoItem>,
+                    <ListView.InfoItem
                       key={`${task.id}-times`}
                       style={{ minWidth: 150, paddingRight: 20 }}
                     >
-                      <ListView.Icon type="fa" size="lg" name="clock-o" />
-                      {elapsedTime}
-                    </ListView.InfoItem>,
-                    <ListView.InfoItem key={`${task.id}-message`}>
-                      <span style={{ textTransform: 'capitalize' }}>
-                        {task.message}
-                      </span>
-                      &nbsp;
-                      {/* Todo: revisit FieldLevelHelp props in patternfly-react to support this */}
-                      <OverlayTrigger
-                        rootClose
-                        trigger="click"
-                        placement="left"
-                        overlay={popoverContent}
-                      >
-                        <Button bsStyle="link">
-                          <Icon type="pf" name="info" />
-                        </Button>
-                      </OverlayTrigger>
+                      <UtilizationBar
+                        now={task.percentComplete}
+                        min={0}
+                        max={100}
+                        description={label}
+                        label=" "
+                        usedTooltipFunction={(max, now) => (
+                          <Tooltip id={Date.now()}>
+                            {now} % {__('Migrated')}
+                          </Tooltip>
+                        )}
+                        availableTooltipFunction={(max, now) => (
+                          <Tooltip id={Date.now()}>
+                            {max - now} % {__('Remaining')}
+                          </Tooltip>
+                        )}
+                        descriptionPlacementTop
+                      />
                     </ListView.InfoItem>
                   ]}
                   actions={
-                    <UtilizationBar
-                      now={task.percentComplete}
-                      min={0}
-                      max={100}
-                      description={label}
-                      label=" "
-                      usedTooltipFunction={(max, now) => (
-                        <Tooltip id={Date.now()}>
-                          {now} % {__('Migrated')}
-                        </Tooltip>
-                      )}
-                      availableTooltipFunction={(max, now) => (
-                        <Tooltip id={Date.now()}>
-                          {max - now} % {__('Remaining')}
-                        </Tooltip>
-                      )}
-                      descriptionPlacementTop
-                    />
+                    <a
+                      href="#"
+                      onClick={e => {
+                        e.preventDefault();
+                        downloadLogAction(task.id);
+                      }}
+                    >
+                      {__('Download Log')}
+                    </a>
                   }
                   stacked
                 />
@@ -506,7 +512,8 @@ class PlanRequestDetailList extends React.Component {
 }
 
 PlanRequestDetailList.propTypes = {
-  planRequestTasks: PropTypes.array
+  planRequestTasks: PropTypes.array,
+  downloadLogAction: PropTypes.func
 };
 
 export default PlanRequestDetailList;


### PR DESCRIPTION
Adds the download log link UI elements for In Progress/Completed plan details  (Not Started detail view is unchanged).

cc: @AparnaKarve - can you begin backend integration?

@vconzola @serenamarie125 - we will need to decide interaction. The way I understand this - we will make an async request to download the log file, the backend will gather the log file from the conversion host, then a Rails controller will submit the file to the UI and our download log promise will resolve. B/c of this - I'd be in favor of showing a spinner OR disabling the link during download. Additionally - if log download request fails, we need some way to notify the user.

thoughts on these scenarios?

Initial screenshot (moved disk utilization to list view additional info section and download log to list view action section, ensured responsive spacing):
<img width="1399" alt="screen shot 2018-05-07 at 4 39 32 pm" src="https://user-images.githubusercontent.com/4237045/39724165-fe066166-5215-11e8-94eb-317616f3deeb.png">

closes #208 