### PR TITLE
plan error reporting popup

### DIFF
--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressCard.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressCard.js
@@ -7,6 +7,7 @@ import {
   Grid,
   Icon,
   OverlayTrigger,
+  Popover,
   Tooltip,
   UtilizationBar,
   Spinner
@@ -55,9 +56,11 @@ const MigrationsInProgressCard = ({
   // UX business rule 1: reflect failed immediately if any single task has failed
   // in the most recent request
   let failed = false;
+  let failedVms = 0;
   mostRecentRequest.miq_request_tasks.forEach(task => {
     if (task.status === 'Error') {
       failed = true;
+      failedVms += 1;
     }
   });
 
@@ -167,24 +170,45 @@ const MigrationsInProgressCard = ({
   return (
     <Grid.Col sm={12} md={6} lg={4}>
       <Card
-        onClick={() => {
-          handleClick(`/migration/plan/${plan.id}`);
+        onClick={e => {
+          if (!e.target.classList.contains('pficon-error-circle-o')) {
+            handleClick(`/migration/plan/${plan.id}`);
+          }
         }}
         matchHeight
         className="in-progress"
       >
         <Card.Heading>
-          <OverlayTrigger
-            overlay={
-              <Tooltip id={`description_${plan.id}`}>{plan.name}</Tooltip>
-            }
-            placement="top"
-            trigger={['hover']}
-            delay={500}
-            rootClose={false}
-          >
-            <h3 className="card-pf-title">
-              {failed && (
+          <h3 className="card-pf-title">
+            {failed && (
+              <OverlayTrigger
+                overlay={
+                  <Popover
+                    id={`description_${plan.id}`}
+                    title={sprintf('%s', plan.name)}
+                  >
+                    <Icon
+                      type="pf"
+                      name="error-circle-o"
+                      size="sm"
+                      style={{
+                        width: 'inherit',
+                        backgroundColor: 'transparent',
+                        paddingRight: 5
+                      }}
+                    />
+                    {sprintf(
+                      __('%s of %s VM migrations failed.'),
+                      failedVms,
+                      totalVMs
+                    )}
+                  </Popover>
+                }
+                placement="top"
+                trigger={['hover']}
+                delay={500}
+                rootClose={false}
+              >
                 <Icon
                   type="pf"
                   name="error-circle-o"
@@ -195,10 +219,10 @@ const MigrationsInProgressCard = ({
                     paddingRight: 10
                   }}
                 />
-              )}
-              {plan.name}
-            </h3>
-          </OverlayTrigger>
+              </OverlayTrigger>
+            )}
+            {plan.name}
+          </h3>
         </Card.Heading>
         <Card.Body>
           <UtilizationBar


### PR DESCRIPTION
Closes #299 

Adds the plan error reporting popup:
* do not proceed to detail if the error icon is clicked (ignore the default card click behavior for the icon)
* show the popup with "{x} of {y} VM migrations failed." message. Use the most recent execution request to determine the number of failed VM tasks.

<img width="797" alt="screen shot 2018-05-20 at 10 25 40 am" src="https://user-images.githubusercontent.com/4237045/40279905-14136352-5c19-11e8-99c1-707219b88b7d.png">



