### PR TITLE
fix spacing on detail view

### DIFF
--- a/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
@@ -428,7 +428,8 @@ class PlanRequestDetailList extends React.Component {
                       style={{
                         flexDirection: 'column',
                         alignItems: 'flex-start',
-                        marginRight: 80
+                        marginRight: 80,
+                        minWidth: 200
                       }}
                     >
                       <div>


### PR DESCRIPTION
While adding the error reporting popup, I noticed some spacing issues w/ the plan detail list view. This adds a min-width to the description so that spacing is consistent.

Before:
<img width="1205" alt="before" src="https://user-images.githubusercontent.com/4237045/40279927-7be518b8-5c19-11e8-9d7e-ce196de9dc79.png">


After:
<img width="1209" alt="after" src="https://user-images.githubusercontent.com/4237045/40279928-7f9f8c2c-5c19-11e8-9fe8-6899c4b191dd.png">
