### PR TITLE
Remove unused MiqV2vUI::ApplicationController

### DIFF
--- a/app/controllers/miq_v2v_ui/application_controller.rb
+++ b/app/controllers/miq_v2v_ui/application_controller.rb
@@ -1,6 +1,0 @@
-module MiqV2vUI
-  # Common class for all plugin controllers.
-  class ApplicationController < ActionController::Base
-    protect_from_forgery with: :exception
-  end
-end


### PR DESCRIPTION
Looks like this may have been originally intended to be the plugin base controller, but:

a) such a thing needs to live in ui-classic, to include all the necessary helpers etc.
b) it is not currently being used

Removing