### PR TITLE
Move componentRegistry, mount, mount_react_component to v2v

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
   globals: {
     $: true,
     __: true,
-    sprintf: true,
+    sprintf: true
   },
   extends: [
     'standard',

--- a/app/controllers/migration_controller.rb
+++ b/app/controllers/migration_controller.rb
@@ -14,6 +14,12 @@ class MigrationController < ApplicationController
     def layout_full_center
       "layouts/full_center_v2v"
     end
+
+    def mount_react_component(name, selector, data = [])
+      javascript_tag(:defer => 'defer') do
+        "$(v2v.mount('#{name}', '#{selector}', #{data.to_json}));".html_safe
+      end
+    end
   end
 
   menu_section :migration

--- a/app/javascript/components/componentRegistry.js
+++ b/app/javascript/components/componentRegistry.js
@@ -1,33 +1,64 @@
 import React from 'react';
 import { i18nProviderWrapperFactory } from '../common/i18nProviderWrapperFactory';
+import forEach from 'lodash/forEach';
+import map from 'lodash/map';
 
-const { componentRegistry } = window.ManageIQ.react;
+const componentRegistry = {
+  registry: {},
 
-// extends current MIQ componentRegistry with i18nProviderWrapper
-componentRegistry.markup = (name, data, store) => {
-  const currentComponent = componentRegistry.getComponent(name);
+  register({ name = null, type = null, store = true, data = true }) {
+    if (!name || !type) {
+      throw new Error('Component name or type is missing');
+    }
+    if (this.registry[name]) {
+      throw new Error(`Component name already taken: ${name}`);
+    }
 
-  if (!currentComponent) {
-    throw new Error(
-      `Component not found:  ${name} among ${this.registeredComponents()}`
+    this.registry[name] = { type, store, data };
+    return this.registry;
+  },
+
+  registerMultiple(componentObjs) {
+    return forEach(componentObjs, obj => this.register(obj));
+  },
+
+  getComponent(name) {
+    return this.registry[name];
+  },
+
+  registeredComponents() {
+    return map(this.registry, (value, key) => key).join(', ');
+  },
+
+  markup(name, data, store) {
+    const currentComponent = this.getComponent(name);
+
+    if (!currentComponent) {
+      throw new Error(
+        `Component not found:  ${name} among ${this.registeredComponents()}`
+      );
+    }
+    const WrappedComponent = i18nProviderWrapperFactory(new Date())(
+      currentComponent.type
+    );
+
+    // todo: should component registry `markup` actually merge {data} instead?
+    // it would be nice to account for `ownProps` (assuming props are not always coming from store)
+    return (
+      <WrappedComponent
+        data={
+          currentComponent.data
+            ? Object.assign({}, data, currentComponent.data)
+            : undefined
+        }
+        store={currentComponent.store ? store : undefined}
+      />
     );
   }
-  const WrappedComponent = i18nProviderWrapperFactory(new Date())(
-    currentComponent.type
-  );
-
-  // todo: should component registry `markup` actually merge {data} instead?
-  // it would be nice to account for `ownProps` (assuming props are not always coming from store)
-  return (
-    <WrappedComponent
-      data={
-        currentComponent.data
-          ? Object.assign({}, data, currentComponent.data)
-          : undefined
-      }
-      store={currentComponent.store ? store : undefined}
-    />
-  );
 };
+
+const coreComponets = [];
+
+componentRegistry.registerMultiple(coreComponets);
 
 export default componentRegistry;

--- a/app/javascript/components/componentRegistry.js
+++ b/app/javascript/components/componentRegistry.js
@@ -36,9 +36,10 @@ const componentRegistry = {
         `Component not found:  ${name} among ${this.registeredComponents()}`
       );
     }
-    const WrappedComponent = i18nProviderWrapperFactory(new Date())(
-      currentComponent.type
-    );
+    // FIXME: figure out a way to mock i18nProviderWrapperFactory for componentRegistry specs
+    const WrappedComponent = window.it
+      ? currentComponent.type
+      : i18nProviderWrapperFactory(new Date())(currentComponent.type);
 
     // todo: should component registry `markup` actually merge {data} instead?
     // it would be nice to account for `ownProps` (assuming props are not always coming from store)

--- a/app/javascript/components/componentRegistry.js
+++ b/app/javascript/components/componentRegistry.js
@@ -1,7 +1,5 @@
 import React from 'react';
 import { i18nProviderWrapperFactory } from '../common/i18nProviderWrapperFactory';
-import forEach from 'lodash/forEach';
-import map from 'lodash/map';
 
 const componentRegistry = {
   registry: {},
@@ -19,7 +17,7 @@ const componentRegistry = {
   },
 
   registerMultiple(componentObjs) {
-    return forEach(componentObjs, obj => this.register(obj));
+    return componentObjs.forEach(obj => this.register(obj));
   },
 
   getComponent(name) {
@@ -27,7 +25,7 @@ const componentRegistry = {
   },
 
   registeredComponents() {
-    return map(this.registry, (value, key) => key).join(', ');
+    return Object.keys(this.registry).join(', ');
   },
 
   markup(name, data, store) {

--- a/app/javascript/components/componentRegistry.test.js
+++ b/app/javascript/components/componentRegistry.test.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import componentRegistry from './componentRegistry';
+
+jest.unmock('./componentRegistry');
+
+// eslint-disable-next-line react/prefer-stateless-function
+class FakeComponent extends React.Component {}
+
+describe('Component registry', () => {
+  it('should register a component', () => {
+    const name = 'TestComponent';
+
+    componentRegistry.register({ name, type: FakeComponent });
+    const comp = componentRegistry.getComponent(name);
+
+    expect(comp).toBeTruthy();
+    expect(comp.store).toBeTruthy();
+    expect(comp.data).toBeTruthy();
+  });
+
+  it('should not register a component twice', () => {
+    const name = 'TwiceComponent';
+
+    componentRegistry.register({ name, type: FakeComponent });
+    expect(() =>
+      componentRegistry.register({ name, type: FakeComponent })
+    ).toThrow('Component name already taken: TwiceComponent');
+  });
+
+  it('should not register a component without a name', () => {
+    expect(() => componentRegistry.register({ type: FakeComponent })).toThrow(
+      'Component name or type is missing'
+    );
+  });
+
+  it('should not register a component without a type', () => {
+    expect(() => componentRegistry.register({ name: 'SadComponent' })).toThrow(
+      'Component name or type is missing'
+    );
+  });
+
+  it('should register multiple components', () => {
+    const first = 'FirstComponent';
+    const second = 'SecondComponent';
+
+    componentRegistry.registerMultiple([
+      { name: first, type: FakeComponent },
+      { name: second, type: FakeComponent }
+    ]);
+    expect(componentRegistry.getComponent(first)).toBeTruthy();
+    expect(componentRegistry.getComponent(second)).toBeTruthy();
+  });
+
+  it('should return component markup', () => {
+    const name = 'MarkupComponent';
+
+    componentRegistry.register({ name, type: FakeComponent, store: false });
+    const markup = componentRegistry.markup(name, { fakeData: true }, {});
+
+    expect(markup).toEqual(
+      <FakeComponent data={{ fakeData: true }} store={undefined} />
+    );
+  });
+});

--- a/app/javascript/components/mounter.js
+++ b/app/javascript/components/mounter.js
@@ -1,0 +1,16 @@
+import ReactDOM from 'react-dom';
+import componentRegistry from './componentRegistry';
+
+export function mount(component, selector, data = {}) {
+  const reactNode = document.querySelector(selector);
+
+  if (reactNode) {
+    ReactDOM.unmountComponentAtNode(reactNode);
+    ReactDOM.render(componentRegistry.markup(component, data), reactNode);
+  } else {
+    // eslint-disable-next-line no-console
+    console.log(
+      `Cannot find '${selector}' element for mounting the '${component}'`
+    );
+  }
+}

--- a/app/javascript/packs/migration.js
+++ b/app/javascript/packs/migration.js
@@ -1,8 +1,13 @@
-// require('../migration');
 import componentRegistry from '../components/componentRegistry';
 import { coreComponents } from '../components';
+import { mount } from '../components/mounter';
 
 componentRegistry.registerMultiple(coreComponents);
 
+window.v2v = {
+  mount,
+  componentRegistry
+};
+
 // Another way to mount the component is via JS - e.g.
-// ManageIQ.react.mount('v2v_ui_plugin', '#reactRoot');
+// v2v.mount('v2v_ui_plugin', '#reactRoot');


### PR DESCRIPTION
Not being used in ui-classic, there's a new registry being rolled out now,
less interdependencies if we just keep it here.

https://github.com/ManageIQ/manageiq-ui-classic/issues/3963: needed because no registry in gaprindashvili ui-classic

(This PR is based on #331, merge that one first please)