### PR TITLE
BootstrapSelect - use global jQuery

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,8 +4,9 @@ module.exports = {
     'jest/globals': true
   },
   globals: {
+    $: true,
     __: true,
-    sprintf: true
+    sprintf: true,
   },
   extends: [
     'standard',

--- a/app/javascript/react/screens/App/common/forms/BootstrapSelect.js
+++ b/app/javascript/react/screens/App/common/forms/BootstrapSelect.js
@@ -9,9 +9,6 @@ import {
 } from 'patternfly-react';
 import { focus } from 'redux-form';
 
-const $ = require('jquery');
-require('bootstrap-select');
-
 export class BootstrapSelect extends React.Component {
   constructor(props) {
     super(props);

--- a/package.json
+++ b/package.json
@@ -57,11 +57,9 @@
     "stylelint-config-standard": "^18.0.0"
   },
   "dependencies": {
-    "bootstrap-select": "~1.12.4",
     "classnames": "^2.2.5",
     "csv": "^2.0.0",
     "file-saver": "^1.3.8",
-    "jquery": "~3.2.1",
     "lodash.orderby": "^4.6.0",
     "moment": "^2.22.0",
     "numeral": "^2.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1357,12 +1357,6 @@ bootstrap-select@1.12.2:
   dependencies:
     jquery ">=1.8"
 
-bootstrap-select@~1.12.4:
-  version "1.12.4"
-  resolved "https://registry.yarnpkg.com/bootstrap-select/-/bootstrap-select-1.12.4.tgz#7f15d3c0ce978868d9c09c70f96624f55fa02ee1"
-  dependencies:
-    jquery ">=1.8"
-
 bootstrap-slider-without-jquery@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/bootstrap-slider-without-jquery/-/bootstrap-slider-without-jquery-10.0.0.tgz#5c304461b3b915037c7c118806c8ca08102f5de3"


### PR DESCRIPTION
to make sure selectpicker is there, even when global jQuery comes from bower
this means we now depend on global jquery + bootstrap-select, but works in master and gaprindashvili

---

Fixes

	miq_debug.self-a72dc0b9f690f63b4688fbca3774709918c11fdfb7b5fc454690d11d007fc88b.js?body=1:29 TypeError: m(...).selectpicker is not a function
		at t.value (BootstrapSelect.js:29)
		at commitLifeCycles (react-dom.production.min.js:159)


https://github.com/ManageIQ/manageiq-ui-classic/issues/3963: needed because otherwise, we need to backport all the changes to support moving ui-classic dependencies from bower to npm. If global jQuery comes from bower, any version of jQuery from npm will not see bootstrap-select.

(This PR *could* be gaprindashvili-only if so desired.)