### PR TITLE
Start polling on the plan page based on more reliable status data

### DIFF
--- a/app/javascript/react/screens/App/Plan/Plan.js
+++ b/app/javascript/react/screens/App/Plan/Plan.js
@@ -65,11 +65,11 @@ class Plan extends React.Component {
         const mostRecentRequest = getMostRecentRequest(miq_requests);
         const planRequestId = mostRecentRequest.id;
         fetchPlanRequestAction(fetchPlanRequestUrl, planRequestId);
-        if (mostRecentRequest.status === 'active') {
-          this.startPolling(planRequestId);
-        } else if (
-          mostRecentRequest.request_state === 'finished' ||
-          mostRecentRequest.status === 'Error'
+        this.startPolling(planRequestId);
+        if (
+          mostRecentRequest.status !== 'active' &&
+          (mostRecentRequest.request_state === 'finished' ||
+            mostRecentRequest.status === 'Error')
         ) {
           this.setState(() => ({
             planFinished: true

--- a/app/javascript/react/screens/App/Plan/Plan.js
+++ b/app/javascript/react/screens/App/Plan/Plan.js
@@ -65,12 +65,9 @@ class Plan extends React.Component {
         const mostRecentRequest = getMostRecentRequest(miq_requests);
         const planRequestId = mostRecentRequest.id;
         fetchPlanRequestAction(fetchPlanRequestUrl, planRequestId);
-        this.startPolling(planRequestId);
-        if (
-          mostRecentRequest.status !== 'active' &&
-          (mostRecentRequest.request_state === 'finished' ||
-            mostRecentRequest.status === 'Error')
-        ) {
+        if (mostRecentRequest.fulfilled_on === null) {
+          this.startPolling(planRequestId);
+        } else {
           this.setState(() => ({
             planFinished: true
           }));

--- a/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
@@ -399,7 +399,7 @@ class PlanRequestDetailList extends React.Component {
                     </div>
                     <div>
                       <b>{__('Description')}: </b>
-                      {task.options.progress.current_description}
+                      {task.options.progress && task.options.progress.current_description}
                     </div>
                     {task.taskCompleted && (
                       <div>

--- a/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
@@ -399,7 +399,8 @@ class PlanRequestDetailList extends React.Component {
                     </div>
                     <div>
                       <b>{__('Description')}: </b>
-                      {task.options.progress && task.options.progress.current_description}
+                      {task.options.progress &&
+                        task.options.progress.current_description}
                     </div>
                     {task.taskCompleted && (
                       <div>


### PR DESCRIPTION
There appears to be some condition where the polling does not start on this page. I loosened the logic here in case we have a new status string, or race condition, in Kedar's environment that is preventing the polling from starting.

I'm hoping this will fix #311 but I need help figuring out how to test it against @kedark3's environment.