### PR TITLE
Use http, not API for querying rails controller endpoints

### DIFF
--- a/app/javascript/common/API.js
+++ b/app/javascript/common/API.js
@@ -1,4 +1,4 @@
-const API = window.API; // eslint-disable-line prefer-destructuring
+const { API } = window;
 
 export default {
   get(url, headers = {}, params = {}) {

--- a/app/javascript/common/http.js
+++ b/app/javascript/common/http.js
@@ -1,0 +1,17 @@
+const { http } = window;
+
+export default {
+  get(url, headers = {}, params = {}) {
+    return http.get(url, {
+      transformResponse: e => ({ data: e }),
+      headers,
+      params
+    });
+  },
+  post(url, data = {}, headers = {}) {
+    return http.post(url, data, {
+      headers,
+      transformResponse: e => ({ data: e })
+    });
+  }
+};

--- a/app/javascript/react/screens/App/Plan/PlanActions.js
+++ b/app/javascript/react/screens/App/Plan/PlanActions.js
@@ -1,6 +1,7 @@
 import URI from 'urijs';
 import { saveAs } from 'file-saver';
 import API from '../../../../common/API';
+import http from '../../../../common/http';
 
 import {
   FETCH_V2V_PLAN_REQUEST,

--- a/app/javascript/react/screens/App/Plan/PlanActions.js
+++ b/app/javascript/react/screens/App/Plan/PlanActions.js
@@ -86,7 +86,8 @@ export const downloadLogAction = task => dispatch => {
   dispatch({
     type: FETCH_V2V_MIGRATION_TASK_LOG,
     payload: new Promise((resolve, reject) => {
-      API.get(`/migration_log/download_migration_log/${task.id}`)
+      http
+        .get(`/migration_log/download_migration_log/${task.id}`)
         .then(response => {
           resolve(response);
           dispatch({


### PR DESCRIPTION
`API.get` does not send the authentication cookie, only the api token.
So MigationLogController can't see the session.

We now have `http` for that (from https://github.com/ManageIQ/manageiq-ui-classic/pull/3662)

Fixes https://github.com/ManageIQ/miq_v2v_ui_plugin/pull/333#issuecomment-391052384

https://github.com/ManageIQ/manageiq-ui-classic/issues/3963: need to backport the http change too for gapri