### PR TITLE
associated plans

### DIFF
--- a/app/javascript/components/index.js
+++ b/app/javascript/components/index.js
@@ -90,7 +90,7 @@ export const coreComponents = [
     data: {
       fetchTransformationMappingsUrl:
         'api/transformation_mappings?expand=resources' +
-        '&attributes=transformation_mapping_items',
+        '&attributes=transformation_mapping_items,service_templates',
       fetchTransformationPlansUrl:
         '/api/service_templates/?' +
         "filter[]=type='ServiceTemplateTransformationPlan'" +

--- a/app/javascript/react/screens/App/Overview/components/InfrastructureMappingsList/InfrastructureMappingsList.js
+++ b/app/javascript/react/screens/App/Overview/components/InfrastructureMappingsList/InfrastructureMappingsList.js
@@ -58,69 +58,104 @@ const InfrastructureMappingsList = ({
         </div>
 
         <ListView style={{ marginTop: 10 }}>
-          {transformationMappings.map(mapping => (
-            <ListView.Item
-              key={mapping.id}
-              heading={mapping.name}
-              description={mapping.description}
-              additionalInfo={[
-                <ListView.InfoItem key={0}>
-                  <Icon type="pf" name="cluster" />
-                  <strong>
-                    {clusterCount(
-                      mapping.transformation_mapping_items,
-                      'source_id'
-                    )}
-                  </strong>&nbsp;{__('Source Clusters')}
-                </ListView.InfoItem>,
-                <ListView.InfoItem key={1}>
-                  <Icon type="pf" name="cluster" />
-                  <strong>
-                    {clusterCount(
-                      mapping.transformation_mapping_items,
-                      'destination_id'
-                    )}
-                  </strong>&nbsp;{__('Target Clusters')}
-                </ListView.InfoItem>
-              ]}
-            >
-              <Grid.Row
-                style={{
-                  paddingBottom: 14
-                }}
+          {transformationMappings.map(mapping => {
+            const sourceClusterCount = clusterCount(
+              mapping.transformation_mapping_items,
+              'source_id'
+            );
+
+            const targetClusterCount = clusterCount(
+              mapping.transformation_mapping_items,
+              'destination_id'
+            );
+
+            const associatedPlansCount =
+              mapping.service_templates && mapping.service_templates.length;
+
+            return (
+              <ListView.Item
+                key={mapping.id}
+                heading={mapping.name}
+                description={mapping.description}
+                additionalInfo={[
+                  <ListView.InfoItem key={0}>
+                    <Icon type="pf" name="cluster" />
+                    <strong>{sourceClusterCount}</strong>&nbsp;
+                    {sourceClusterCount === 1
+                      ? __('Source Cluster')
+                      : __('Source Clusters')}
+                  </ListView.InfoItem>,
+
+                  <ListView.InfoItem key={1}>
+                    <Icon type="pf" name="cluster" />
+                    <strong>{targetClusterCount}</strong>&nbsp;
+                    {targetClusterCount === 1
+                      ? __('Target Cluster')
+                      : __('Target Clusters')}
+                  </ListView.InfoItem>,
+                  associatedPlansCount ? (
+                    <ListView.InfoItem key={2}>
+                      <Icon type="pf" name="catalog" />
+                      <strong>{associatedPlansCount}</strong>&nbsp;
+                      {associatedPlansCount === 1
+                        ? __('Associated Plan')
+                        : __('Associated Plans')}
+                    </ListView.InfoItem>
+                  ) : null
+                ]}
               >
-                <Grid.Col sm={12}>
-                  {__('Completed: ')}
-                  {moment(mapping.created_at).format('MMMM Do YYYY, h:mm a')}
-                </Grid.Col>
-              </Grid.Row>
-              <Grid.Row>
-                <Grid.Col sm={4}>
-                  <b>{__('Source Clusters')}</b>
-                </Grid.Col>
-                <Grid.Col sm={4}>
-                  <b>{__('Target Clusters')}</b>
-                </Grid.Col>
-                <Grid.Col smOffset={4} />
-              </Grid.Row>
-              <Grid.Row />
-              {mapping.transformation_mapping_items
-                .filter(item => item.source_type.toLowerCase() === 'emscluster')
-                .map((item, i) => (
-                  <React.Fragment key={`${i}-${item.id}`}>
-                    <Grid.Row>
-                      <Grid.Col sm={4}>
-                        {clusterName(clusters, item.source_id)}
-                      </Grid.Col>
-                      <Grid.Col sm={4}>
-                        {clusterName(clusters, item.destination_id)}
-                      </Grid.Col>
-                      <Grid.Col smOffset={4} />
-                    </Grid.Row>
-                  </React.Fragment>
-                ))}
-            </ListView.Item>
-          ))}
+                <Grid.Row
+                  style={{
+                    paddingBottom: 14
+                  }}
+                >
+                  <Grid.Col sm={12}>
+                    {__('Completed: ')}
+                    {moment(mapping.created_at).format('MMMM Do YYYY, h:mm a')}
+                  </Grid.Col>
+                </Grid.Row>
+                <Grid.Row>
+                  <Grid.Col sm={4}>
+                    <b>{__('Source Clusters')}</b>
+                  </Grid.Col>
+                  <Grid.Col sm={4}>
+                    <b>{__('Target Clusters')}</b>
+                  </Grid.Col>
+                  <Grid.Col sm={4}>
+                    {associatedPlansCount > 0 ? (
+                      <b>{__('Associated Plans')}</b>
+                    ) : null}
+                  </Grid.Col>
+                </Grid.Row>
+                <Grid.Row />
+                {mapping.transformation_mapping_items
+                  .filter(
+                    item => item.source_type.toLowerCase() === 'emscluster'
+                  )
+                  .map((item, i) => (
+                    <React.Fragment key={`${i}-${item.id}`}>
+                      <Grid.Row>
+                        <Grid.Col sm={4}>
+                          {clusterName(clusters, item.source_id)}
+                        </Grid.Col>
+                        <Grid.Col sm={4}>
+                          {clusterName(clusters, item.destination_id)}
+                        </Grid.Col>
+                        <Grid.Col sm={4}>
+                          {associatedPlansCount > 0
+                            ? mapping.service_templates.map((plan, id) => (
+                                <div key={id}>
+                                  <span>{plan.name}</span>&nbsp;&nbsp;
+                                </div>
+                              ))
+                            : null}
+                        </Grid.Col>
+                      </Grid.Row>
+                    </React.Fragment>
+                  ))}
+              </ListView.Item>
+            );
+          })}
         </ListView>
       </React.Fragment>
     ) : (


### PR DESCRIPTION
Closes #321 

* adds the associated plans attribute to the transformation mapping query so they are also returned in that query
* displays the associated plans count in the list view item and the associated plan names in the list view detail. Display nothing if there are no associated plans.
* correctly pluralizes "Source Cluster(s)", "Target Cluster(s)", and "Associated Plan(s)" in the list item count - previously that was not done...

Would like to iterate on #310 next after we have API direction.

![screen shot 2018-05-24 at 10 49 12 am](https://user-images.githubusercontent.com/4237045/40493431-baa98f00-5f40-11e8-834d-e9a7da6275cc.png)

