### PR TITLE
Use utf8 decode on csv data to address internationalized chars

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/components/CSVDropzoneField.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/components/CSVDropzoneField.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import csv from 'csv';
+import utf8 from 'utf8';
 import { bindMethods, Button, EmptyState } from 'patternfly-react';
 import Dropzone from 'react-dropzone';
 
@@ -67,7 +68,7 @@ class CSVDropzoneField extends React.Component {
   }
 
   trimWhiteSpaces = csvRows =>
-    csvRows.map(row => row.map(value => value.trim()));
+    csvRows.map(row => row.map(value => utf8.decode(value).trim()));
 
   mapCSVColumnNameToKey = headerRow => {
     headerRow[headerRow.findIndex(k => k === __('Name'))] = 'name';

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.0",
     "babel-preset-es2015": "^6.24.1",
+    "babel-preset-minify": "^0.2.0",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-1": "^6.24.1",
-    "babel-preset-minify": "^0.2.0",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "enzyme-to-json": "^3.3.3",
@@ -82,6 +82,7 @@
     "sortabular": "^1.5.1",
     "table-resolver": "^3.2.0",
     "urijs": "^1.19.0",
+    "utf8": "^3.0.0",
     "uuid": "^3.2.1"
   },
   "jest": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6193,6 +6193,10 @@ user-home@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"
 
+utf8@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/utf8/-/utf8-3.0.0.tgz#f052eed1364d696e769ef058b183df88c87f69d1"
+
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"


### PR DESCRIPTION
Apply utf8 decoding to csv data to display internationalized characters like `à`, `ë` correctly.

Before -

<img width="900" alt="screen shot 2018-05-24 at 2 01 23 pm" src="https://user-images.githubusercontent.com/1538216/40513566-066dce8c-5f5b-11e8-860f-76087f1abfcb.png">

After - 
<img width="904" alt="screen shot 2018-05-24 at 1 58 14 pm" src="https://user-images.githubusercontent.com/1538216/40513584-186fa18c-5f5b-11e8-91ff-77e8608230cf.png">


https://bugzilla.redhat.com/show_bug.cgi?id=1570992