### PR TITLE
Pass DualPaneMapperCount as a prop

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/DualPaneMapper/DualPaneMapperList.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/DualPaneMapper/DualPaneMapperList.js
@@ -3,17 +3,7 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { Spinner } from 'patternfly-react';
 
-const DualPaneMapperList = ({ children, listTitle, loading, id }) => {
-  const childrenArray = React.Children.toArray(children);
-
-  const counter = childrenArray.find(
-    child => child.type.name === 'DualPaneMapperCount'
-  );
-
-  const listItems =
-    counter &&
-    childrenArray.filter(child => child.type.name === 'DualPaneMapperListItem');
-
+const DualPaneMapperList = ({ children, listTitle, loading, id, counter }) => {
   const classes = cx('dual-pane-mapper-items-container', {
     'has-counter': counter,
     loading
@@ -25,15 +15,9 @@ const DualPaneMapperList = ({ children, listTitle, loading, id }) => {
         <label htmlFor="availableTitle">
           <span id="listTitle">{listTitle}</span>
         </label>
-        {counter ? (
-          <div className={classes} id={id}>
-            {loading ? <Spinner loading /> : listItems}
-          </div>
-        ) : (
-          <div className={classes} id={id}>
-            {loading ? <Spinner loading /> : children}
-          </div>
-        )}
+        <div className={classes} id={id}>
+          {loading ? <Spinner loading /> : children}
+        </div>
       </div>
       {counter && counter}
     </div>
@@ -44,7 +28,8 @@ DualPaneMapperList.propTypes = {
   children: PropTypes.node,
   listTitle: PropTypes.string,
   id: PropTypes.string,
-  loading: PropTypes.bool
+  loading: PropTypes.bool,
+  counter: PropTypes.node
 };
 
 export default DualPaneMapperList;

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm/ClustersStepForm.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm/ClustersStepForm.js
@@ -143,6 +143,13 @@ class ClustersStepForm extends React.Component {
       selectedMapping
     } = this.state;
 
+    const counter = (
+      <DualPaneMapperCount
+        selectedItems={selectedSourceClusters.length}
+        totalItems={sourceClustersFilter(sourceClusters, input.value).length}
+      />
+    );
+
     return (
       <div className="dual-pane-mapper-form">
         <DualPaneMapper
@@ -159,6 +166,7 @@ class ClustersStepForm extends React.Component {
               id="source_clusters"
               listTitle="Source Clusters"
               loading={isFetchingSourceClusters}
+              counter={counter}
             >
               {sourceClustersFilter(sourceClusters, input.value).map(item => (
                 <DualPaneMapperListItem
@@ -179,12 +187,6 @@ class ClustersStepForm extends React.Component {
                   handleKeyPress={this.selectSourceCluster}
                 />
               ))}
-              <DualPaneMapperCount
-                selectedItems={selectedSourceClusters.length}
-                totalItems={
-                  sourceClustersFilter(sourceClusters, input.value).length
-                }
-              />
             </DualPaneMapperList>
           )}
           {targetClusters && (

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/DatastoresStepForm.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/DatastoresStepForm.js
@@ -374,6 +374,13 @@ class DatastoresStepForm extends React.Component {
       'is-hidden': !selectedCluster
     });
 
+    const counter = (
+      <DualPaneMapperCount
+        selectedItems={selectedSourceDatastores.length}
+        totalItems={sourceDatastoreFilter(sourceDatastores, input.value).length}
+      />
+    );
+
     return (
       <div className={classes}>
         <DualPaneMapper
@@ -389,6 +396,7 @@ class DatastoresStepForm extends React.Component {
             id="source_datastores"
             listTitle="Source Datastores"
             loading={isFetchingSourceDatastores}
+            counter={counter}
           >
             {sourceDatastores &&
               sourceDatastoreFilter(sourceDatastores, input.value).map(item => (
@@ -406,12 +414,6 @@ class DatastoresStepForm extends React.Component {
                   handleKeyPress={this.selectSourceDatastore}
                 />
               ))}
-            <DualPaneMapperCount
-              selectedItems={selectedSourceDatastores.length}
-              totalItems={
-                sourceDatastoreFilter(sourceDatastores, input.value).length
-              }
-            />
           </DualPaneMapperList>
           <DualPaneMapperList
             id="target_datastores"

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/NetworksStepForm.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/NetworksStepForm.js
@@ -369,6 +369,15 @@ class NetworksStepForm extends React.Component {
       'is-hidden': !selectedCluster
     });
 
+    const counter = (
+      <DualPaneMapperCount
+        selectedItems={selectedSourceNetworks.length}
+        totalItems={
+          sourceNetworksFilter(groupedSourceNetworks, input.value).length
+        }
+      />
+    );
+
     return (
       <div className={classes}>
         <DualPaneMapper
@@ -384,6 +393,7 @@ class NetworksStepForm extends React.Component {
             id="source_networks"
             listTitle="Source Networks"
             loading={isFetchingSourceNetworks}
+            counter={counter}
           >
             {groupedSourceNetworks &&
               sourceNetworksFilter(groupedSourceNetworks, input.value).map(
@@ -405,12 +415,6 @@ class NetworksStepForm extends React.Component {
                   />
                 )
               )}
-            <DualPaneMapperCount
-              selectedItems={selectedSourceNetworks.length}
-              totalItems={
-                sourceNetworksFilter(groupedSourceNetworks, input.value).length
-              }
-            />
           </DualPaneMapperList>
           <DualPaneMapperList
             id="target_networks"


### PR DESCRIPTION
Production builds seem to have an issue filtering the children of
DualPaneMapperList to separate out the counter. To avoid this all
together, just pass in the counter component as a prop and let all the
children be DualPaneMapperListItem(s)

## Notes
1. Closes https://github.com/ManageIQ/miq_v2v_ui_plugin/issues/348
2. As this does not manifest in development, but only in production builds, we will have to wait until this change is incorporated into the nightlies to verify.  To test this locally, go through the Mapping Wizard and verify that nothing has actually changed
3. In the following screenshot you can see that the count component is being rendered alongside the list items (spun up a summit demo to see this)
    <img width="1114" alt="developer_tools_-_https___1cloudforms-rhpdsrhmicroredhat-aceruhmj_srv_ravcloud_com_migration" src="https://user-images.githubusercontent.com/15141412/40543518-c7b1a70c-5ff2-11e8-8289-7a90c2a6280f.png">
  which leads me to believe that this [variable](https://github.com/ManageIQ/miq_v2v_ui_plugin/blob/master/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/DualPaneMapper/DualPaneMapperList.js#L9) is always returning null for some reason
