### PR TITLE
[GAPRINDASHVILI] Fix "<select> per page" styling in patternfly 3.25

### DIFF
--- a/app/javascript/react/screens/App/Overview/Overview.scss
+++ b/app/javascript/react/screens/App/Overview/Overview.scss
@@ -91,6 +91,19 @@ hr {
   margin-left: initial;
 }
 
+// Patternfly 3.25 compatibility - comes from patternfly/patternfly#910, made specific to v2v for gaprindashvili
+.miq-v2v .content-view-pf-pagination .form-group {
+  .pagination-pf-pagesize.bootstrap-select.btn-group,
+  .pagination-pf-pagesize.btn-group {
+    display: flex;
+    float: none;
+    margin-bottom: 0;
+    margin-left: 0;
+    margin-right: 5px;
+    width: auto;
+  }
+}
+
 // The below style could be moved to core for the ConfirmModal component (or first, to the CSS in patternfly-react for that)
 
 .confirm-warning-icon {

--- a/app/views/layouts/_full_center_v2v.html.haml
+++ b/app/views/layouts/_full_center_v2v.html.haml
@@ -3,3 +3,7 @@
 
 .container-fluid.container-pf-nav-pf-vertical.container-pf-nav-pf-vertical-with-sub-menus{:style => "overflow: hidden; height: 100%;"}
   = yield
+
+:javascript
+  // gaprindashvili-specific hack to support v2v-specific styling even for dialogs (outside #reactRoot)
+  $('body').addClass('miq-v2v');


### PR DESCRIPTION
The css comes from patternfly/patternfly#910, wrapped in a `.miq-v2v` so that we can be sure this only affects v2v screeens.

Unfortunately dialogs get opened directly under body, so any such class needs to live on body itself.

(Fortunately there are no cross-controller ajax transitions in gaprindashvili.)