### PR TITLE
[WIP] i18n fixes and cleanups

### DIFF
--- a/app/javascript/react/config/config.js
+++ b/app/javascript/react/config/config.js
@@ -3,12 +3,10 @@ import PlanContainer from '../screens/App/Plan';
 
 export const links = [
   {
-    text: 'Overview',
     path: 'migration/',
     component: OverviewContainer
   },
   {
-    text: 'Plan',
     path: 'migration/plan/:id',
     component: PlanContainer
   }

--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -176,7 +176,7 @@ class Overview extends React.Component {
 
     createTransformationPlanRequestAction(url).then(() => {
       retryMigrationAction(planId);
-      setMigrationsFilterAction('Migration Plans in Progress');
+      setMigrationsFilterAction(__('Migration Plans in Progress'));
       fetchTransformationPlansAction(fetchTransformationPlansUrl);
     });
   };
@@ -350,9 +350,11 @@ class Overview extends React.Component {
     const toolbarContent = (
       <Toolbar>
         <Breadcrumb.Item href="/dashboard/maintab?tab=compute">
-          Compute
+          {__('Compute')}
         </Breadcrumb.Item>
-        <Breadcrumb.Item active>Migration</Breadcrumb.Item>
+        <Breadcrumb.Item active>
+          {__('Migration')}
+        </Breadcrumb.Item>
       </Toolbar>
     );
 

--- a/app/javascript/react/screens/App/Overview/OverviewReducer.js
+++ b/app/javascript/react/screens/App/Overview/OverviewReducer.js
@@ -53,7 +53,7 @@ export const initialState = Immutable({
   isContinuingToPlan: false,
   shouldReloadMappings: false,
   clusters: [],
-  migrationsFilter: 'Migration Plans Not Started',
+  migrationsFilter: __('Migration Plans Not Started'),
   showDeleteConfirmationModal: false
 });
 

--- a/app/javascript/react/screens/App/Overview/components/AggregateCards/ActiveTransformationPlans/ActiveTransformationPlans.js
+++ b/app/javascript/react/screens/App/Overview/components/AggregateCards/ActiveTransformationPlans/ActiveTransformationPlans.js
@@ -20,8 +20,8 @@ const ActiveTransformationPlans = ({
 }) => {
   const countDescription =
     activePlans.length === 1
-      ? 'Migration Plan In Progress'
-      : 'Migration Plans In Progress';
+      ? __('Migration Plan In Progress')
+      : __('Migration Plans In Progress');
 
   const erroredPlans = activePlans.filter(plan => {
     if (allRequestsWithTasks && allRequestsWithTasks.length > 0) {

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/PlanWizard.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/PlanWizard.js
@@ -51,12 +51,12 @@ class PlanWizard extends React.Component {
         planWizardOptionsStep.values.migration_plan_choice_radio ===
         'migration_plan_now'
       ) {
-        setMigrationsFilterAction('Migration Plans in Progress');
+        setMigrationsFilterAction(__('Migration Plans in Progress'));
       } else if (
         planWizardOptionsStep.values.migration_plan_choice_radio ===
         'migration_plan_later'
       ) {
-        setMigrationsFilterAction('Migration Plans Not Started');
+        setMigrationsFilterAction(__('Migration Plans Not Started'));
       }
     }
 

--- a/app/javascript/react/screens/App/Plan/components/PlanVmsList.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanVmsList.js
@@ -305,7 +305,7 @@ class PlanVmsList extends React.Component {
                     key={`${task.id}-message`}
                     style={{ minWidth: 150, paddingRight: 20 }}
                   >
-                    Not started
+                    {__('Not started')}
                   </ListView.InfoItem>
                 ]}
                 actions={
@@ -313,7 +313,7 @@ class PlanVmsList extends React.Component {
                     now={0}
                     min={0}
                     max={100}
-                    description="0 GBs Migrated"
+                    description={__('0 GBs Migrated')}
                     label=" "
                     usedTooltipFunction={(max, now) => (
                       <Tooltip id={Date.now()}>
@@ -358,13 +358,13 @@ PlanVmsList.propTypes = {
   planVms: PropTypes.array
 };
 
-PlanVmsList.sortFields = [{ id: 'name', title: 'Name', isNumeric: false }];
+PlanVmsList.sortFields = [{ id: 'name', title: __('Name'), isNumeric: false }];
 
 PlanVmsList.filterTypes = [
   {
     id: 'name',
-    title: 'Name',
-    placeholder: 'Filter by Name',
+    title: __('Name'),
+    placeholder: __('Filter by Name'),
     filterType: 'text'
   }
 ];


### PR DESCRIPTION
```
app/javascript/react/config/config.js
4:export const links = [

app/javascript/react/config/Routes.js
4:import { links } from './config';
9:  links.map(({ path, component }) => {
```

So, we only use `links` in Routes, where we only read `path` and `component`.

So, the `text` attribute is dead now, removing.

(If `text` should not be dead, we should add gettext and use it somewhere.)

---

Plus various other i18n fixes from comments