### PR TITLE
Emptystate.title is a required field, cannot be undefied, ie-empty

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/components/CSVDropzoneField.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/components/CSVDropzoneField.js
@@ -84,7 +84,7 @@ class CSVDropzoneField extends React.Component {
         >
           <EmptyState>
             <EmptyState.Icon type="pf" name="import" />
-            <EmptyState.Title />
+            <EmptyState.Title>{__('Import File')}</EmptyState.Title>
             <EmptyState.Info>
               {__('Import a file including a list of VMs to be migrated.')}
             </EmptyState.Info>


### PR DESCRIPTION
closes #378

No visual changes, just rids ourselves of that nasty warning... 
<img width="907" alt="screen shot 2018-06-01 at 2 25 01 pm" src="https://user-images.githubusercontent.com/6640236/40857189-70d0dece-65a8-11e8-946d-a8a7e534c785.png">


But also... maybe... this should be propagated back to pfr? In the form of consistent spacing of both the an empty state body and title from the icon...