### PR TITLE
Fix non-unique keys while rendering Plans

### DIFF
--- a/app/javascript/react/screens/App/Overview/components/DeleteInfrastructureMappingConfirmationModal/DeleteInfrastructureMappingConfirmationModal.js
+++ b/app/javascript/react/screens/App/Overview/components/DeleteInfrastructureMappingConfirmationModal/DeleteInfrastructureMappingConfirmationModal.js
@@ -13,25 +13,42 @@ const unUsedMappingInPlans = (
     plan =>
       plan.options.config_info.transformation_mapping_id === mappingToDelete.id
   );
-  plansWithMappingToBeDeleted.map(plan => planNames.push(plan.name));
+  plansWithMappingToBeDeleted.map(plan =>
+    planNames.push({ name: plan.name, id: plan.id })
+  );
 
   const plansWithErrorWithMappingToBeDeleted = finishedWithErrorTransformationPlans.filter(
     plan =>
       plan.options.config_info.transformation_mapping_id === mappingToDelete.id
   );
-  plansWithErrorWithMappingToBeDeleted.map(plan => planNames.push(plan.name));
+  plansWithErrorWithMappingToBeDeleted.map(plan =>
+    planNames.push({ name: plan.name, id: plan.id })
+  );
 
   if (planNames.length > 0) {
-    const deleteMessageAboutUnMigratedVMs = __(
-      'The infrastructure mapping is associated with migration plans that include unmigrated VMs. Deleting the mapping will prevent you from migrating the VMs in these plans:'
-    );
-    const deleteMessageAboutPlansUsingMapping = (
+    const deleteMessageAboutUnMigratedVMs = (
       <div>
-        <h4>{deleteMessageAboutUnMigratedVMs}</h4>
-        <strong>{planNames.map(plan => <ul key={plan}>{plan}</ul>)}</strong>
+        <h4>
+          {__(
+            'The infrastructure mapping is associated with migration plans that include unmigrated VMs. Deleting the mapping will prevent you from migrating the VMs in these plans:'
+          )}
+        </h4>
       </div>
     );
-    return <div>{deleteMessageAboutPlansUsingMapping}</div>;
+
+    const deleteMessageAboutPlansUsingMapping = (
+      <div className="warning-modal-body-enable-scrollbar">
+        <strong>
+          {planNames.map(plan => <ul key={plan.id}>{plan.name}</ul>)}
+        </strong>
+      </div>
+    );
+    return (
+      <div>
+        {deleteMessageAboutUnMigratedVMs}
+        {deleteMessageAboutPlansUsingMapping}
+      </div>
+    );
   }
   return '';
 };

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/WarningModal/WarningModal.scss
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/WarningModal/WarningModal.scss
@@ -23,3 +23,8 @@
 .warning-modal-body--list {
   margin-left: 40px;
 }
+
+.warning-modal-body-enable-scrollbar {
+  height: 80px;
+  overflow: auto;
+}


### PR DESCRIPTION
Few adjustments to the Delete confirmation Modal

- Fixed non-unique keys while rendering Plans
- Added a scrollbar for the Plans div

Covers an edge case that @michaelkro came across, where we could have 
(a) identical Plan Names
(b) > 5 Plan Names to be displayed in the Modal

<img width="621" alt="screen shot 2018-06-01 at 2 29 29 pm" src="https://user-images.githubusercontent.com/1538216/40864453-c6119d42-65a8-11e8-91c0-413d8041753b.png">
