### PR TITLE
Add status icon to breadcrumb bar in Plan page

### DIFF
--- a/app/javascript/react/screens/App/Plan/Plan.js
+++ b/app/javascript/react/screens/App/Plan/Plan.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Immutable from 'seamless-immutable';
 import { Link } from 'react-router-dom';
-import { Breadcrumb, Spinner } from 'patternfly-react';
+import { Breadcrumb, Spinner, Icon } from 'patternfly-react';
 import Toolbar from '../../../config/Toolbar';
 import PlanRequestDetailList from './components/PlanRequestDetailList/PlanRequestDetailList';
 import PlanVmsList from './components/PlanVmsList';
@@ -99,6 +99,8 @@ class Plan extends React.Component {
   render() {
     const {
       planName,
+      planArchived,
+      planRequestFailed,
       isRejectedPlanRequest,
       isFetchingPlanRequest,
       isRejectedPlan,
@@ -117,6 +119,19 @@ class Plan extends React.Component {
       planRequestPreviouslyFetched
     } = this.state;
 
+    const icons = {
+      inProgress: <Icon type="pf" name="spinner2" />,
+      success: <Icon type="pf" name="ok" />,
+      failed: <Icon type="pf" name="error-circle-o" />,
+      archived: <Icon type="fa" name="archive" />
+    };
+    const breadcrumbIcon =
+      (planRequestFailed && icons.failed) ||
+      (planArchived && icons.archived) ||
+      (planFinished && icons.success) ||
+      (!planNotStarted && icons.inProgress) ||
+      null;
+
     return (
       <React.Fragment>
         <Toolbar>
@@ -127,7 +142,12 @@ class Plan extends React.Component {
             <Link to="/migration">{__('Migration')}</Link>
           </li>
           {!isRejectedPlan &&
-            planName && <Breadcrumb.Item active>{planName}</Breadcrumb.Item>}
+            planName && (
+              <Breadcrumb.Item active>
+                {breadcrumbIcon}
+                {breadcrumbIcon ? ` ${planName}` : planName}
+              </Breadcrumb.Item>
+            )}
         </Toolbar>
 
         <Spinner
@@ -192,6 +212,8 @@ Plan.propTypes = {
   fetchPlanRequestUrl: PropTypes.string.isRequired,
   fetchPlanRequestAction: PropTypes.func.isRequired,
   planName: PropTypes.string,
+  planRequestFailed: PropTypes.bool,
+  planArchived: PropTypes.bool,
   planRequestTasks: PropTypes.array,
   isRejectedPlanRequest: PropTypes.bool,
   isFetchingPlanRequest: PropTypes.bool,

--- a/app/javascript/react/screens/App/Plan/PlanReducer.js
+++ b/app/javascript/react/screens/App/Plan/PlanReducer.js
@@ -18,10 +18,12 @@ export const initialState = Immutable({
   planRequestPreviouslyFetched: false,
   errorPlanRequest: null,
   planRequestTasks: [],
+  planRequestFailed: false,
   isFetchingPlan: false,
   isRejectedPlan: false,
   errorPlan: null,
   plan: {},
+  planArchived: false,
   isQueryingVms: false,
   isRejectedVms: false,
   errorVms: null,
@@ -142,6 +144,7 @@ export default (state = initialState, action) => {
           return state
             .set('planRequestPreviouslyFetched', true)
             .set('planRequestTasks', newTasks)
+            .set('planRequestFailed', payload.data.status === 'Error')
             .set('isRejectedPlanRequest', false)
             .set('errorPlanRequest', null)
             .set('isFetchingPlanRequest', false);
@@ -165,6 +168,7 @@ export default (state = initialState, action) => {
       return state
         .set('plan', action.payload.data)
         .set('planName', action.payload.data.name)
+        .set('planArchived', !!action.payload.data.deleted_on)
         .set('isFetchingPlan', false)
         .set('isRejectedPlan', false)
         .set('errorPlan', null);


### PR DESCRIPTION
I need help testing this one with an "archived" plan. I took a guess that the `request_state` would equal "archived" instead of "finished", but I need someone to help me find the real value there. @AparnaKarve maybe you can help me there?  (i promise i'll stop bugging you soon 😂 )

Also, as implemented, there will be no icon in the breadcrumb bar if the plan is not started or in progress, only if it is completed or archived. Not sure if that's what we wanted, and if not, what should we use for those other icons @vconzola @serenamarie125 ?

Once the above is addressed, this closes #347 .

Note also: I hate that I have both `planRequestState` and `planRequestStatus` passed down.. they are named after where they come from in the API, but seen next to each other they are a little confusing. @priley86 i'm open to redux property name suggestions, haha. We may not need planRequestState anyway, if the archived state is inferred from elsewhere.