### PR TITLE
Display 'Duplicate VM' Reason for duplicate VMs discovered after the CSV parsing

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepConstants.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepConstants.js
@@ -7,5 +7,6 @@ export const V2V_VM_POST_VALIDATION_REASONS = {
   in_other_plan: __('VM exists in a different migration plan'),
   migrated: __('VM has already been migrated'),
   not_exist: __('VM does not exist'),
-  ok: __('VM available for migration')
+  ok: __('VM available for migration'),
+  duplicate: __('Duplicate VM')
 };

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepConstants.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepConstants.js
@@ -9,5 +9,7 @@ export const V2V_VM_POST_VALIDATION_REASONS = {
   not_exist: __('VM does not exist'),
   ok: __('VM available for migration'),
   duplicate: __('Duplicate VM'),
-  no_info_available: __('No information available')
+  no_info_available: __(
+    'VM unavailable for migration, no information available'
+  )
 };

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepConstants.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepConstants.js
@@ -8,5 +8,6 @@ export const V2V_VM_POST_VALIDATION_REASONS = {
   migrated: __('VM has already been migrated'),
   not_exist: __('VM does not exist'),
   ok: __('VM available for migration'),
-  duplicate: __('Duplicate VM')
+  duplicate: __('Duplicate VM'),
+  no_info_available: __('No information available')
 };

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepReducer.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepReducer.js
@@ -30,14 +30,21 @@ const manageDuplicateVMRows = (vm, vmIndex, uniqueIds) => {
   }
 };
 
-const _formatValidVms = vms =>
-  vms &&
-  vms.map(v => {
-    v.valid = true;
-    v.allocated_size = numeral(v.allocated_size).format('0.00b');
-    v.reason = V2V_VM_POST_VALIDATION_REASONS[v.reason];
-    return v;
-  });
+const _formatValidVms = vms => {
+  const uniqueIds = vms && [...new Set(vms.map(value => value.id))];
+  let vIndex = 0;
+  return (
+    vms &&
+    vms.map(v => {
+      vIndex += 1;
+      v.valid = true;
+      v.allocated_size = numeral(v.allocated_size).format('0.00b');
+      v.reason = V2V_VM_POST_VALIDATION_REASONS[v.reason];
+      manageDuplicateVMRows(v, vIndex, uniqueIds);
+      return v;
+    })
+  );
+};
 
 const _formatInvalidVms = vms => {
   const uniqueIds = vms && [...new Set(vms.map(value => value.id))];

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepReducer.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepReducer.js
@@ -30,6 +30,17 @@ const manageDuplicateVMRows = (vm, vmIndex, uniqueIds) => {
   }
 };
 
+const manageBlankReason = vm => {
+  if (!vm.reason) {
+    vm.reason = V2V_VM_POST_VALIDATION_REASONS.no_info_available;
+  }
+};
+
+const manageOddCSVImportErrors = (vm, vmIndex, uniqueIds) => {
+  manageDuplicateVMRows(vm, vmIndex, uniqueIds);
+  manageBlankReason(vm);
+};
+
 const _formatValidVms = vms => {
   const uniqueIds = vms && [...new Set(vms.map(value => value.id))];
   let vIndex = 0;
@@ -40,7 +51,7 @@ const _formatValidVms = vms => {
       v.valid = true;
       v.allocated_size = numeral(v.allocated_size).format('0.00b');
       v.reason = V2V_VM_POST_VALIDATION_REASONS[v.reason];
-      manageDuplicateVMRows(v, vIndex, uniqueIds);
+      manageOddCSVImportErrors(v, vIndex, uniqueIds);
       return v;
     })
   );
@@ -63,7 +74,7 @@ const _formatInvalidVms = vms => {
       } else {
         v.invalid = true;
       }
-      manageDuplicateVMRows(v, vIndex, uniqueIds);
+      manageOddCSVImportErrors(v, vIndex, uniqueIds);
       return v;
     })
   );

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepReducer.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepReducer.js
@@ -43,11 +43,9 @@ const manageOddCSVImportErrors = (vm, vmIndex, uniqueIds) => {
 
 const _formatValidVms = vms => {
   const uniqueIds = vms && [...new Set(vms.map(value => value.id))];
-  let vIndex = 0;
   return (
     vms &&
-    vms.map(v => {
-      vIndex += 1;
+    vms.map((v, vIndex) => {
       v.valid = true;
       v.allocated_size = numeral(v.allocated_size).format('0.00b');
       v.reason = V2V_VM_POST_VALIDATION_REASONS[v.reason];
@@ -59,11 +57,9 @@ const _formatValidVms = vms => {
 
 const _formatInvalidVms = vms => {
   const uniqueIds = vms && [...new Set(vms.map(value => value.id))];
-  let vIndex = 0;
   return (
     vms &&
-    vms.map(v => {
-      vIndex += 1;
+    vms.map((v, vIndex) => {
       v.allocated_size = numeral(v.allocated_size).format('0.00b');
       v.reason = V2V_VM_POST_VALIDATION_REASONS[v.reason];
       if (

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepReducer.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepReducer.js
@@ -25,22 +25,36 @@ const _formatValidVms = vms =>
     v.reason = V2V_VM_POST_VALIDATION_REASONS[v.reason];
     return v;
   });
-const _formatInvalidVms = vms =>
-  vms &&
-  vms.map(v => {
-    v.allocated_size = numeral(v.allocated_size).format('0.00b');
-    v.reason = V2V_VM_POST_VALIDATION_REASONS[v.reason];
-    if (
-      v.reason === V2V_VM_POST_VALIDATION_REASONS.migrated ||
-      v.reason === V2V_VM_POST_VALIDATION_REASONS.in_other_plan
-    ) {
-      v.warning = true;
-    } else {
-      v.invalid = true;
-    }
 
-    return v;
-  });
+const _formatInvalidVms = vms => {
+  const uniqueIds = [...new Set(vms.map(value => value.id))];
+  return (
+    vms &&
+    vms.map(v => {
+      v.allocated_size = numeral(v.allocated_size).format('0.00b');
+      v.reason = V2V_VM_POST_VALIDATION_REASONS[v.reason];
+      if (
+        v.reason === V2V_VM_POST_VALIDATION_REASONS.migrated ||
+        v.reason === V2V_VM_POST_VALIDATION_REASONS.in_other_plan
+      ) {
+        v.warning = true;
+      } else {
+        v.invalid = true;
+      }
+
+      const index = v.id && uniqueIds.indexOf(v.id);
+      if (index > -1) {
+        uniqueIds.splice(index, 1);
+      } else if (index === -1) {
+        v.reason = V2V_VM_POST_VALIDATION_REASONS.duplicate;
+        v.warning = false;
+        v.invalid = true;
+      }
+      return v;
+    })
+  );
+};
+
 const _formatConflictVms = vms =>
   vms &&
   vms.map(v => {


### PR DESCRIPTION
Display 'Duplicate VM' Reason for duplicate VMs discovered after the CSV parsing.

<img width="819" alt="screen shot 2018-06-07 at 10 34 07 am" src="https://user-images.githubusercontent.com/1538216/41123739-835de504-6a54-11e8-826a-72d83634141b.png">

<img width="832" alt="screen shot 2018-06-06 at 5 03 21 pm" src="https://user-images.githubusercontent.com/1538216/41123818-c86539fe-6a54-11e8-9d22-650b22566bf8.png">


Also addressed a case where no Reason is being sent by the backend. 
In this situation, 'No information Available' should be displayed instead of a blank text

<img width="837" alt="screen shot 2018-06-08 at 10 16 13 am" src="https://user-images.githubusercontent.com/1538216/41171731-6faec1e2-6b06-11e8-9b13-e258f92f9fbc.png">



Fixes https://github.com/ManageIQ/miq_v2v_ui_plugin/issues/207
https://bugzilla.redhat.com/show_bug.cgi?id=1571960