### PR TITLE
check for the `transformation` flag to enable/disable Migration

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,11 @@
 # MiqV2vUI::Engine.routes.draw do
-Rails.application.routes.draw do
-  match '/migration' => 'migration#index', :via => [:get]
-  match 'migration/*page' => 'migration#index', :via => [:get]
+if ::Settings.product.transformation == true
+  Rails.application.routes.draw do
+    match '/migration' => 'migration#index', :via => [:get]
+    match 'migration/*page' => 'migration#index', :via => [:get]
 
-  get "migration_log/download_migration_log(/:id)",
-    :action     => 'download_migration_log',
-    :controller => 'migration_log'
+    get "migration_log/download_migration_log(/:id)",
+      :action     => 'download_migration_log',
+      :controller => 'migration_log'
+  end
 end

--- a/lib/miq_v2v_ui/engine.rb
+++ b/lib/miq_v2v_ui/engine.rb
@@ -12,7 +12,7 @@ module MiqV2vUI
 
     initializer 'plugin' do
       Menu::CustomLoader.register(
-          Menu::Item.new('migration', N_('Migration'), 'miq_report', {:feature => 'miq_report', :any => true}, '/migration', :default, :compute)
+        ::Settings.product.transformation == true ? Menu::Item.new('migration', N_('Migration'), 'miq_report', {:feature => 'miq_report', :any => true}, '/migration', :default, :compute) : nil
       )
     end
   end


### PR DESCRIPTION
Check for the `::Settings.product.transformation` flag in order to enable/disable Migration.

For some reason changes done in this PR https://github.com/ManageIQ/miq_v2v_ui_plugin/pull/190 were lost, so adding them here again.

https://bugzilla.redhat.com/show_bug.cgi?id=1583819