### PR TITLE
Allow mapping Target Datasources that have less allocated space than Source Datastores - addresses #345

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStep.js
@@ -98,8 +98,7 @@ class MappingWizardDatastoresStep extends React.Component {
       sourceDatastores,
       targetDatastores,
       form,
-      showAlertAction,
-      hideAlertAction
+      showAlertAction
     } = this.props;
 
     const { selectedCluster, selectedClusterMapping } = this.state;
@@ -137,7 +136,6 @@ class MappingWizardDatastoresStep extends React.Component {
           isFetchingTargetDatastores={isFetchingTargetDatastores}
           validate={length({ min: 1 })}
           showAlertAction={showAlertAction}
-          hideAlertAction={hideAlertAction}
         />
       </div>
     );
@@ -157,8 +155,7 @@ MappingWizardDatastoresStep.propTypes = {
   isRejectedTargetDatastores: PropTypes.bool,
   form: PropTypes.string,
   pristine: PropTypes.bool,
-  showAlertAction: PropTypes.func,
-  hideAlertAction: PropTypes.func
+  showAlertAction: PropTypes.func
 };
 MappingWizardDatastoresStep.defaultProps = {
   clusterMappings: [],
@@ -173,8 +170,7 @@ MappingWizardDatastoresStep.defaultProps = {
   isRejectedTargetDatastores: false,
   form: '',
   pristine: true,
-  showAlertAction: noop,
-  hideAlertAction: noop
+  showAlertAction: noop
 };
 
 export default reduxForm({

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/DatastoresStepForm.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/DatastoresStepForm.js
@@ -13,10 +13,8 @@ import {
   targetDatastoreTreeViewInfo,
   sourceDatastoreInfo,
   targetDatastoreInfo,
-  targetDatastoreAvailableSpace,
-  totalUsedSpace,
-  errorMessage,
-  updateMappings
+  updateMappings,
+  negativeAvailableSpace
 } from './helpers';
 
 class DatastoresStepForm extends React.Component {
@@ -39,93 +37,28 @@ class DatastoresStepForm extends React.Component {
   }
 
   selectSourceDatastore = sourceDatastore => {
-    const { selectedTargetDatastore, selectedSourceDatastores } = this.state;
-    const { value: datastoresStepMappings } = this.props.input;
-    const { showAlertAction, hideAlertAction } = this.props;
-
-    const mappingExistsForTargetDatastore =
-      selectedTargetDatastore &&
-      datastoresStepMappings.some(targetClusterWithDatastoreMappings =>
-        targetClusterWithDatastoreMappings.nodes.some(
-          targetDatastoreWithSourceDatastores =>
-            targetDatastoreWithSourceDatastores.id ===
-            selectedTargetDatastore.id
-        )
+    this.setState(prevState => {
+      const isAlreadySelected = prevState.selectedSourceDatastores.some(
+        datastore => datastore.id === sourceDatastore.id
       );
-
-    const isNotAlreadySelected = !selectedSourceDatastores.some(
-      datastore => datastore.id === sourceDatastore.id
-    );
-
-    if (
-      selectedTargetDatastore &&
-      mappingExistsForTargetDatastore &&
-      isNotAlreadySelected &&
-      targetDatastoreAvailableSpace(
-        selectedTargetDatastore,
-        datastoresStepMappings
-      ) < totalUsedSpace([...selectedSourceDatastores, sourceDatastore])
-    ) {
-      showAlertAction(errorMessage);
-    } else if (
-      selectedTargetDatastore &&
-      isNotAlreadySelected &&
-      selectedTargetDatastore.free_space <
-        totalUsedSpace([...selectedSourceDatastores, sourceDatastore])
-    ) {
-      showAlertAction(errorMessage);
-    } else {
-      this.setState(prevState => {
-        const isAlreadySelected = prevState.selectedSourceDatastores.some(
-          datastore => datastore.id === sourceDatastore.id
-        );
-        if (isAlreadySelected) {
-          return {
-            selectedSourceDatastores: prevState.selectedSourceDatastores.filter(
-              datastore => datastore.id !== sourceDatastore.id
-            )
-          };
-        }
-        hideAlertAction();
+      if (isAlreadySelected) {
         return {
-          selectedSourceDatastores: [
-            ...prevState.selectedSourceDatastores,
-            sourceDatastore
-          ]
+          selectedSourceDatastores: prevState.selectedSourceDatastores.filter(
+            datastore => datastore.id !== sourceDatastore.id
+          )
         };
-      });
-    }
+      }
+      return {
+        selectedSourceDatastores: [
+          ...prevState.selectedSourceDatastores,
+          sourceDatastore
+        ]
+      };
+    });
   };
 
   selectTargetDatastore = targetDatastore => {
-    const { selectedSourceDatastores } = this.state;
-    const { value: datastoresStepMappings } = this.props.input;
-    const { showAlertAction, hideAlertAction } = this.props;
-
-    const mappingExistsForTargetDatastore = datastoresStepMappings.some(
-      targetClusterWithDatastoreMappings =>
-        targetClusterWithDatastoreMappings.nodes.some(
-          targetDatastoreWithSourceDatastores =>
-            targetDatastoreWithSourceDatastores.id === targetDatastore.id
-        )
-    );
-
-    if (
-      selectedSourceDatastores.length > 0 &&
-      mappingExistsForTargetDatastore &&
-      targetDatastoreAvailableSpace(targetDatastore, datastoresStepMappings) <
-        totalUsedSpace(selectedSourceDatastores)
-    ) {
-      showAlertAction(errorMessage);
-    } else if (
-      selectedSourceDatastores.length > 0 &&
-      targetDatastore.free_space < totalUsedSpace(selectedSourceDatastores)
-    ) {
-      showAlertAction(errorMessage);
-    } else {
-      hideAlertAction();
-      this.setState(() => ({ selectedTargetDatastore: targetDatastore }));
-    }
+    this.setState(() => ({ selectedTargetDatastore: targetDatastore }));
   };
 
   addDatastoreMapping = () => {
@@ -159,6 +92,12 @@ class DatastoresStepForm extends React.Component {
                   prevState.selectedTargetDatastore,
                   prevState.selectedSourceDatastores
                 ),
+                icon: negativeAvailableSpace(
+                  prevState.selectedTargetDatastore,
+                  prevState.selectedSourceDatastores
+                )
+                  ? 'pficon-warning-triangle-o'
+                  : 'fa fa-folder',
                 selectable: true,
                 selected: false,
                 state: {
@@ -192,6 +131,12 @@ class DatastoresStepForm extends React.Component {
                         mapping,
                         mapping.nodes.concat(prevState.selectedSourceDatastores)
                       ),
+                      icon: negativeAvailableSpace(
+                        mapping,
+                        mapping.nodes.concat(prevState.selectedSourceDatastores)
+                      )
+                        ? 'pficon-warning-triangle-o'
+                        : 'fa fa-folder',
                       nodes: mapping.nodes.concat(
                         prevState.selectedSourceDatastores.map(datastore => ({
                           ...datastore,
@@ -216,6 +161,12 @@ class DatastoresStepForm extends React.Component {
                   prevState.selectedTargetDatastore,
                   prevState.selectedSourceDatastores
                 ),
+                icon: negativeAvailableSpace(
+                  prevState.selectedTargetDatastore,
+                  prevState.selectedSourceDatastores
+                )
+                  ? 'pficon-warning-triangle-o'
+                  : 'fa fa-folder',
                 selectable: true,
                 selected: false,
                 state: {
@@ -443,7 +394,5 @@ DatastoresStepForm.propTypes = {
   sourceDatastores: PropTypes.array,
   targetDatastores: PropTypes.array,
   isFetchingSourceDatastores: PropTypes.bool,
-  isFetchingTargetDatastores: PropTypes.bool,
-  showAlertAction: PropTypes.func,
-  hideAlertAction: PropTypes.func
+  isFetchingTargetDatastores: PropTypes.bool
 };

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/DatastoresStepForm.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/DatastoresStepForm.js
@@ -13,8 +13,7 @@ import {
   targetDatastoreTreeViewInfo,
   sourceDatastoreInfo,
   targetDatastoreInfo,
-  updateMappings,
-  negativeAvailableSpace
+  updateMappings
 } from './helpers';
 
 class DatastoresStepForm extends React.Component {
@@ -92,12 +91,6 @@ class DatastoresStepForm extends React.Component {
                   prevState.selectedTargetDatastore,
                   prevState.selectedSourceDatastores
                 ),
-                icon: negativeAvailableSpace(
-                  prevState.selectedTargetDatastore,
-                  prevState.selectedSourceDatastores
-                )
-                  ? 'pficon-warning-triangle-o'
-                  : 'fa fa-folder',
                 selectable: true,
                 selected: false,
                 state: {
@@ -131,12 +124,6 @@ class DatastoresStepForm extends React.Component {
                         mapping,
                         mapping.nodes.concat(prevState.selectedSourceDatastores)
                       ),
-                      icon: negativeAvailableSpace(
-                        mapping,
-                        mapping.nodes.concat(prevState.selectedSourceDatastores)
-                      )
-                        ? 'pficon-warning-triangle-o'
-                        : 'fa fa-folder',
                       nodes: mapping.nodes.concat(
                         prevState.selectedSourceDatastores.map(datastore => ({
                           ...datastore,
@@ -161,12 +148,6 @@ class DatastoresStepForm extends React.Component {
                   prevState.selectedTargetDatastore,
                   prevState.selectedSourceDatastores
                 ),
-                icon: negativeAvailableSpace(
-                  prevState.selectedTargetDatastore,
-                  prevState.selectedSourceDatastores
-                )
-                  ? 'pficon-warning-triangle-o'
-                  : 'fa fa-folder',
                 selectable: true,
                 selected: false,
                 state: {

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/__tests__/DatastoresStepForm.test.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/__tests__/DatastoresStepForm.test.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import DatastoresStepForm from '../DatastoresStepForm';
 
-import { datastoreUsedSpace } from '../helpers';
-
 import {
   sourceClusters,
   targetClusters,
@@ -208,75 +206,6 @@ describe('#selectSourceDatastore', () => {
       showAlertAction
     };
   });
-
-  describe('when a target datastore is selected first', () => {
-    test('does not allow selection that exceeds target datastore capacity', () => {
-      const [sourceDatastoreToSelect] = sourceDatastores;
-      const targetDatastoreToSelect = { ...targetDatastores[0], free_space: 0 };
-
-      const wrapper = shallow(
-        <DatastoresStepForm
-          {...props}
-          sourceDatastores={[sourceDatastoreToSelect]}
-          targetDatastores={[targetDatastoreToSelect]}
-        />
-      );
-
-      wrapper
-        .find('DualPaneMapperListItem')
-        .at(1)
-        .prop('handleClick')(targetDatastoreToSelect);
-      wrapper
-        .find('DualPaneMapperListItem')
-        .at(0)
-        .prop('handleClick')(sourceDatastoreToSelect);
-
-      expect(showAlertAction).toHaveBeenCalled();
-    });
-
-    test('if a mapping exists for the target datastore, does not allow selection that will exceed target datastore capacity', () => {
-      const [sourceDatastoreToSelect, mappedSourceDatastore] = sourceDatastores;
-      const targetDatastoreToSelect = {
-        ...targetDatastores[0],
-        free_space: datastoreUsedSpace(mappedSourceDatastore)
-      };
-
-      input = {
-        ...input,
-        value: [
-          {
-            ...targetCluster,
-            nodes: [
-              {
-                ...targetDatastoreToSelect,
-                nodes: [mappedSourceDatastore]
-              }
-            ]
-          }
-        ]
-      };
-
-      const wrapper = shallow(
-        <DatastoresStepForm
-          {...props}
-          input={input}
-          sourceDatastores={[sourceDatastoreToSelect, mappedSourceDatastore]}
-          targetDatastores={[targetDatastoreToSelect]}
-        />
-      );
-
-      wrapper
-        .find('DualPaneMapperListItem')
-        .at(1)
-        .prop('handleClick')(targetDatastoreToSelect);
-      wrapper
-        .find('DualPaneMapperListItem')
-        .at(0)
-        .prop('handleClick')(sourceDatastoreToSelect);
-
-      expect(showAlertAction).toHaveBeenCalled();
-    });
-  });
 });
 
 describe('#selectTargetDatastore', () => {
@@ -294,76 +223,5 @@ describe('#selectTargetDatastore', () => {
       hideAlertAction,
       showAlertAction
     };
-  });
-
-  describe('when a source datastore is selected first', () => {
-    test('does not allow selection if the target datastore does not have enough capacity', () => {
-      const [sourceDatastoreToSelect] = sourceDatastores;
-      const targetDatastoreToSelect = {
-        ...targetDatastores[0],
-        free_space: datastoreUsedSpace(sourceDatastoreToSelect) - 1
-      };
-
-      const wrapper = shallow(
-        <DatastoresStepForm
-          {...props}
-          sourceDatastores={[sourceDatastoreToSelect]}
-          targetDatastores={[targetDatastoreToSelect]}
-        />
-      );
-
-      wrapper
-        .find('DualPaneMapperListItem')
-        .at(0)
-        .prop('handleClick')(sourceDatastoreToSelect);
-      wrapper
-        .find('DualPaneMapperListItem')
-        .at(1)
-        .prop('handleClick')(targetDatastoreToSelect);
-
-      expect(showAlertAction).toHaveBeenCalled();
-    });
-
-    test('if a mapping exists for the target datastore, does not allow selection if it does not have enough capacity', () => {
-      const [sourceDatastoreToSelect, mappedSourceDatastore] = sourceDatastores;
-      const targetDatastoreToSelect = {
-        ...targetDatastores[0],
-        free_space: datastoreUsedSpace(mappedSourceDatastore)
-      };
-      input = {
-        ...input,
-        value: [
-          {
-            ...targetCluster,
-            nodes: [
-              {
-                ...targetDatastoreToSelect,
-                nodes: [mappedSourceDatastore]
-              }
-            ]
-          }
-        ]
-      };
-
-      const wrapper = shallow(
-        <DatastoresStepForm
-          {...props}
-          input={input}
-          sourceDatastores={[sourceDatastoreToSelect, mappedSourceDatastore]}
-          targetDatastores={[targetDatastoreToSelect]}
-        />
-      );
-
-      wrapper
-        .find('DualPaneMapperListItem')
-        .at(0)
-        .prop('handleClick')(sourceDatastoreToSelect);
-      wrapper
-        .find('DualPaneMapperListItem')
-        .at(1)
-        .prop('handleClick')(targetDatastoreToSelect);
-
-      expect(showAlertAction).toHaveBeenCalled();
-    });
   });
 });

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/helpers.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/helpers.js
@@ -1,5 +1,3 @@
-import numeral from 'numeral';
-
 export const datastoreUsedSpace = (datastore = {}) =>
   datastore.total_space - datastore.free_space;
 
@@ -34,47 +32,13 @@ export const targetDatastoreAvailableSpace = (
 };
 
 export const sourceDatastoreInfo = sourceDatastore =>
-  sprintf(
-    __('%s \\ %s (%s)'),
-    sourceDatastore.providerName,
-    sourceDatastore.name,
-    numeral(datastoreUsedSpace(sourceDatastore)).format('0.00b')
-  );
+  sprintf(__('%s \\ %s'), sourceDatastore.providerName, sourceDatastore.name);
 
 export const targetDatastoreInfo = (targetDatastore, datastoresStepMappings) =>
-  sprintf(
-    __('%s \\ %s (%s avail)'),
-    targetDatastore.providerName,
-    targetDatastore.name,
-    numeral(
-      targetDatastoreAvailableSpace(targetDatastore, datastoresStepMappings)
-    ).format('0.00b')
-  );
+  sprintf(__('%s \\ %s'), targetDatastore.providerName, targetDatastore.name);
 
-export const targetDatastoreTreeViewInfo = (
-  targetDatastore,
-  sourceDatastores
-) => {
-  const { total_space, free_space } = targetDatastore;
-  const availableSpace = free_space - totalUsedSpace(sourceDatastores);
-
-  return sprintf(
-    __('%s (%s total, %s avail)'),
-    targetDatastore.name,
-    numeral(total_space).format('0.00b'),
-    numeral(availableSpace).format('0.00b')
-  );
-};
-
-export const negativeAvailableSpace = (targetDatastore, sourceDatastores) => {
-  const { free_space } = targetDatastore;
-  const availableSpace = free_space - totalUsedSpace(sourceDatastores);
-
-  if (numeral(availableSpace).format('0.00b') < 0) {
-    return true;
-  }
-  return false;
-};
+export const targetDatastoreTreeViewInfo = targetDatastore =>
+  targetDatastore.name;
 
 export const errorMessage = __(
   'The size of the selected source datastores exceeds the available space in the target datastore'

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/helpers.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/helpers.js
@@ -66,6 +66,16 @@ export const targetDatastoreTreeViewInfo = (
   );
 };
 
+export const negativeAvailableSpace = (targetDatastore, sourceDatastores) => {
+  const { free_space } = targetDatastore;
+  const availableSpace = free_space - totalUsedSpace(sourceDatastores);
+
+  if (numeral(availableSpace).format('0.00b') < 0) {
+    return true;
+  }
+  return false;
+};
+
 export const errorMessage = __(
   'The size of the selected source datastores exceeds the available space in the target datastore'
 );


### PR DESCRIPTION
Allow mapping Target Datasources that have less allocated space than Source Datastores

Before -
<img width="903" alt="screen shot 2018-06-20 at 10 05 49 am" src="https://user-images.githubusercontent.com/1538216/41673368-92a0f2b4-7471-11e8-8f33-4937cd29346e.png">

After (no numerical information) -
<img width="901" alt="screen shot 2018-06-20 at 10 04 32 am" src="https://user-images.githubusercontent.com/1538216/41673387-a582620a-7471-11e8-9457-7f755b63c954.png">



Fixes https://github.com/ManageIQ/miq_v2v_ui_plugin/issues/345