### PR TITLE
remove filter label

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/components/PlanWizardVMStepTable.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/components/PlanWizardVMStepTable.js
@@ -557,7 +557,6 @@ class PlanWizardVMStepTable extends React.Component {
                       onRemove={this.removeFilter}
                       filterData={item}
                     >
-                      {__('label=')}
                       {item.label}
                     </Filter.Item>
                   ))}


### PR DESCRIPTION
Remove the "label=" label from the Plan Wizard VM table filter to be consistent with the Plan Detail filter labels.