### PR TITLE
Make the elapsed time clocks start ticking!

### DIFF
--- a/app/javascript/components/dates/IsoElapsedTime.js
+++ b/app/javascript/components/dates/IsoElapsedTime.js
@@ -1,6 +1,6 @@
 import moment from 'moment';
 
-export const IsoElpasedTime = (startTime, endTime) => {
+export const IsoElapsedTime = (startTime, endTime) => {
   let elapsedHours = moment(endTime).diff(startTime, 'hours');
   const elapsedMinutes = moment(endTime).diff(startTime, 'minutes') % 60;
   const elapsedSeconds = moment(endTime).diff(startTime, 'seconds') % 60;

--- a/app/javascript/components/dates/TickingIsoElapsedTime.js
+++ b/app/javascript/components/dates/TickingIsoElapsedTime.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { IsoElapsedTime } from './IsoElapsedTime';
+
+class TickingIsoElapsedTime extends React.Component {
+  constructor() {
+    super();
+    this.state = { now: Date.now() };
+    this._tickInterval = null;
+    this.tick = this.tick.bind(this);
+  }
+
+  tick() {
+    this.setState({ now: Date.now() });
+  }
+
+  componentDidMount() {
+    this._tickInterval = setInterval(this.tick, 1000);
+  }
+
+  componentWillUnmount() {
+    clearInterval(this._tickInterval);
+  }
+  
+  render() {
+    const { startTime } = this.props;
+    const { now } = this.state;
+    return (
+      <React.Fragment>
+        {IsoElapsedTime(new Date(startTime), now)}
+      </React.Fragment>
+    );
+  }
+
+}
+
+TickingIsoElapsedTime.propTypes = {
+  startTime: PropTypes.string, // any string you can pass to new Date()
+};
+
+export default TickingIsoElapsedTime;

--- a/app/javascript/components/dates/TickingIsoElapsedTime.js
+++ b/app/javascript/components/dates/TickingIsoElapsedTime.js
@@ -3,15 +3,14 @@ import PropTypes from 'prop-types';
 import { IsoElapsedTime } from './IsoElapsedTime';
 
 class TickingIsoElapsedTime extends React.Component {
-  constructor() {
-    super();
-    this.state = { now: Date.now() };
+  constructor(props) {
+    super(props);
+    this.state = {
+      now: props.endTime || Date.now()
+    };
     this._tickInterval = null;
+    this.dateProps = this.dateProps.bind(this);
     this.tick = this.tick.bind(this);
-  }
-
-  tick() {
-    this.setState({ now: Date.now() });
   }
 
   componentDidMount() {
@@ -21,21 +20,42 @@ class TickingIsoElapsedTime extends React.Component {
   componentWillUnmount() {
     clearInterval(this._tickInterval);
   }
-  
-  render() {
-    const { startTime } = this.props;
-    const { now } = this.state;
-    return (
-      <React.Fragment>
-        {IsoElapsedTime(new Date(startTime), now)}
-      </React.Fragment>
-    );
+
+  dateProps() {
+    // The new Date() constructor, when passed a Date object, just returns that object.
+    // So it can be used to "cast" unknown string-or-Date props into known Date objects.
+    const { startTime, endTime } = this.props;
+    return {
+      startTime: new Date(startTime),
+      endTime: endTime ? new Date(endTime) : null
+    };
   }
 
+  tick() {
+    const { endTime } = this.dateProps();
+    this.setState({
+      now: endTime || Date.now()
+    });
+  }
+
+  render() {
+    const { startTime } = this.dateProps();
+    const { now } = this.state;
+    return <React.Fragment>{IsoElapsedTime(startTime, now)}</React.Fragment>;
+  }
 }
 
 TickingIsoElapsedTime.propTypes = {
-  startTime: PropTypes.string, // any string you can pass to new Date()
+  startTime: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.instanceOf(Date)
+  ]),
+  endTime: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)])
+};
+
+TickingIsoElapsedTime.defaultProps = {
+  endTime: null // If a null endTime is passed, the time will tick each second.
+  // A non-null endTime will stop the ticking and just display the difference.
 };
 
 export default TickingIsoElapsedTime;

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { noop, Button, ListView, Grid, Spinner, Icon } from 'patternfly-react';
-import { IsoElpasedTime } from '../../../../../../components/dates/IsoElapsedTime';
+import { IsoElapsedTime } from '../../../../../../components/dates/IsoElapsedTime';
 import OverviewEmptyState from '../OverviewEmptyState/OverviewEmptyState';
 import getMostRecentRequest from '../../../common/getMostRecentRequest';
 
@@ -48,7 +48,7 @@ const MigrationsCompletedList = ({
               if (tasks[key]) succeedCount += 1;
             });
 
-            const elapsedTime = IsoElpasedTime(
+            const elapsedTime = IsoElapsedTime(
               new Date(
                 mostRecentRequest && mostRecentRequest.options.delivered_on
               ),

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressCard.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressCard.js
@@ -12,7 +12,7 @@ import {
   UtilizationBar,
   Spinner
 } from 'patternfly-react';
-import { IsoElpasedTime } from '../../../../../../components/dates/IsoElapsedTime';
+import TickingIsoElapsedTime from '../../../../../../components/dates/TickingIsoElapsedTime';
 import getMostRecentRequest from '../../../common/getMostRecentRequest';
 
 const MigrationsInProgressCard = ({
@@ -104,9 +104,8 @@ const MigrationsInProgressCard = ({
   );
 
   // UX business rule 4: reflect most request recent elapsed time
-  const elapsedTime = IsoElpasedTime(
-    new Date(mostRecentRequest.created_on),
-    Date.now()
+  const elapsedTime = (
+    <TickingIsoElapsedTime startTime={mostRecentRequest.created_on} />
   );
 
   // Tooltips

--- a/app/javascript/react/screens/App/Plan/PlanReducer.js
+++ b/app/javascript/react/screens/App/Plan/PlanReducer.js
@@ -1,6 +1,6 @@
 import Immutable from 'seamless-immutable';
 import numeral from 'numeral';
-import { IsoElpasedTime } from '../../../../components/dates/IsoElapsedTime';
+import { IsoElapsedTime } from '../../../../components/dates/IsoElapsedTime';
 
 import {
   FETCH_V2V_PLAN_REQUEST,
@@ -84,7 +84,7 @@ const _formatPlanRequestDetails = data => {
       const currentTime = new Date();
       const startDateTime = taskDetails.delivered_on;
       const lastUpdateDateTime = taskDetails.updated_on;
-      taskDetails.elapsedTime = IsoElpasedTime(
+      taskDetails.elapsedTime = IsoElapsedTime(
         startDateTime,
         taskDetails.completed ? lastUpdateDateTime : currentTime
       );

--- a/app/javascript/react/screens/App/Plan/PlanReducer.js
+++ b/app/javascript/react/screens/App/Plan/PlanReducer.js
@@ -1,6 +1,5 @@
 import Immutable from 'seamless-immutable';
 import numeral from 'numeral';
-import { IsoElapsedTime } from '../../../../components/dates/IsoElapsedTime';
 
 import {
   FETCH_V2V_PLAN_REQUEST,
@@ -81,14 +80,10 @@ const _formatPlanRequestDetails = data => {
         [taskDetails.descriptionPrefix, taskDetails.vmName] = grepVMName;
       }
 
-      const currentTime = new Date();
       const startDateTime = taskDetails.delivered_on;
       const lastUpdateDateTime = taskDetails.updated_on;
-      taskDetails.elapsedTime = IsoElapsedTime(
-        startDateTime,
-        taskDetails.completed ? lastUpdateDateTime : currentTime
-      );
       taskDetails.startDateTime = startDateTime;
+      taskDetails.lastUpdateDateTime = lastUpdateDateTime;
 
       if (taskDetails.completed) {
         taskDetails.completedSuccessfully =

--- a/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
@@ -27,6 +27,7 @@ import {
   ACTIVE_PLAN_SORT_FIELDS,
   FINISHED_PLAN_SORT_FIELDS
 } from './PlanRequestDetailListConstants';
+import TickingIsoElapsedTime from '../../../../../../components/dates/TickingIsoElapsedTime';
 
 class PlanRequestDetailList extends React.Component {
   static getDerivedStateFromProps(nextProps) {
@@ -440,7 +441,12 @@ class PlanRequestDetailList extends React.Component {
                       </div>
                       <div>
                         <ListView.Icon type="fa" size="lg" name="clock-o" />
-                        {task.elapsedTime}
+                        <TickingIsoElapsedTime
+                          startTime={task.startDateTime}
+                          endTime={
+                            task.completed ? task.lastUpdateDateTime : null
+                          }
+                        />
                       </div>
                     </ListView.InfoItem>,
                     <ListView.InfoItem


### PR DESCRIPTION
I added a reusable `TickingIsoElapsedTime` component, which takes as props a `startTime` (which can be either a string or a `Date()`), and an optional `endTime`. It'll tick once per second if the endTime is null, or show the total elapsed time if endTime is non-null.

Also it renders as a `React.Fragment`, so you can stick it as a child anywhere and it will add only the text node to your DOM. So we can use this inside any element.

Thanks for bearing with me on this, I was caught up working on http://what-is-react.surge.sh/ today.

Fixes #338.

![pexxovqa3a 1](https://user-images.githubusercontent.com/811963/41494952-7299e67c-70ea-11e8-9b97-174e2ba8b11b.gif)
