### PR TITLE
Use request_state attribute to control polling

### DIFF
--- a/app/javascript/react/screens/App/Plan/Plan.js
+++ b/app/javascript/react/screens/App/Plan/Plan.js
@@ -63,7 +63,7 @@ class Plan extends React.Component {
         const mostRecentRequest = getMostRecentRequest(miq_requests);
         const planRequestId = mostRecentRequest.id;
         fetchPlanRequestAction(fetchPlanRequestUrl, planRequestId);
-        if (mostRecentRequest.fulfilled_on === null) {
+        if (mostRecentRequest.request_state === 'active') {
           this.startPolling(planRequestId);
         } else {
           this.setState(() => ({


### PR DESCRIPTION
`fulfilled_on === null` works well for the master branch, but seems to be an undefined in gaprindashvili until the request is actually finished.
This is affecting polling and hence the auto-refresh on the page.

The `request_state` attribute should work for both master and gaprindashvili

This is a possible fix for
https://bugzilla.redhat.com/show_bug.cgi?id=1588577

-- will be confirmed after some testing
