### PR TITLE
Use virtual columns when filtering archived plans

### DIFF
--- a/app/javascript/components/index.js
+++ b/app/javascript/components/index.js
@@ -97,7 +97,7 @@ export const coreComponents = [
       fetchTransformationPlansUrl:
         '/api/service_templates/?' +
         "filter[]=type='ServiceTemplateTransformationPlan'" +
-        '&filter[]=deleted_on=nil' +
+        '&filter[]=active=true' +
         '&expand=resources' +
         '&attributes=name,description,miq_requests,options,created_at' +
         '&sort_by=updated_at' +
@@ -105,7 +105,7 @@ export const coreComponents = [
       fetchArchivedTransformationPlansUrl:
         '/api/service_templates/?' +
         "filter[]=type='ServiceTemplateTransformationPlan'" +
-        '&filter[]=deleted_on!=nil' +
+        '&filter[]=archived=true' +
         '&expand=resources' +
         '&attributes=name,description,miq_requests,options,created_at' +
         '&sort_by=updated_at' +

--- a/app/javascript/react/screens/App/Plan/PlanActions.js
+++ b/app/javascript/react/screens/App/Plan/PlanActions.js
@@ -68,7 +68,7 @@ export const _getPlanActionCreator = url => dispatch =>
 
 export const fetchPlanAction = (url, id) => {
   const uri = new URI(`${url}/${id}`);
-  uri.addSearch({ attributes: 'miq_requests' });
+  uri.addSearch({ attributes: 'miq_requests,archived,active' });
   return _getPlanActionCreator(uri.toString());
 };
 

--- a/app/javascript/react/screens/App/Plan/PlanReducer.js
+++ b/app/javascript/react/screens/App/Plan/PlanReducer.js
@@ -163,7 +163,7 @@ export default (state = initialState, action) => {
       return state
         .set('plan', action.payload.data)
         .set('planName', action.payload.data.name)
-        .set('planArchived', action.payload.data.archived)
+        .set('planArchived', !!action.payload.data.archived)
         .set('isFetchingPlan', false)
         .set('isRejectedPlan', false)
         .set('errorPlan', null);

--- a/app/javascript/react/screens/App/Plan/PlanReducer.js
+++ b/app/javascript/react/screens/App/Plan/PlanReducer.js
@@ -163,7 +163,7 @@ export default (state = initialState, action) => {
       return state
         .set('plan', action.payload.data)
         .set('planName', action.payload.data.name)
-        .set('planArchived', !!action.payload.data.deleted_on)
+        .set('planArchived', action.payload.data.archived)
         .set('isFetchingPlan', false)
         .set('isRejectedPlan', false)
         .set('errorPlan', null);


### PR DESCRIPTION
We can now use the virtual columns via the aliases introduced by https://github.com/ManageIQ/manageiq/pull/17553 instead of the `deleted_on` attribute