### PR TITLE
Add v2v plugin branch and commit sha in the main html [#422]

### DIFF
--- a/app/controllers/migration_controller.rb
+++ b/app/controllers/migration_controller.rb
@@ -20,6 +20,11 @@ class MigrationController < ApplicationController
         "$(v2v.mount('#{name}', '#{selector}', #{data.to_json}));".html_safe
       end
     end
+
+    def migration_sha
+      version = vmdb_build_info(:version)
+      "#{version}.#{`git ls-remote https://github.com/ManageIQ/miq_v2v_ui_plugin.git #{version}`.split('refs')[0].try(:strip!) || 'undefined'}"
+    end
   end
 
   menu_section :migration

--- a/app/views/migration/index.html.haml
+++ b/app/views/migration/index.html.haml
@@ -1,2 +1,2 @@
-%div#reactRoot{:style => 'height: 100%;'}
+%div#reactRoot{:style => 'height: 100%;', :v2v_sha => migration_sha}
   = mount_react_component('manageiq-v2v', '#reactRoot', { user: @current_user })


### PR DESCRIPTION
Add v2v branch and commit sha in the main html

What was suggested here https://github.com/ManageIQ/miq_v2v_ui_plugin/issues/422#issuecomment-398808617 is applicable to all plugins, and may have to be implemented on a global level, possibly from miq core. While it is a complete solution, it may take a while to implement considering the extra styling required in the About Modal for the scrolling.
So for now what we could do is -  tackle this from our end.
That said, let's go with @priley86 's suggestion to put the hash in the html. 


See the screenshot below and checkout the commit sha in the highlighted line -

<img width="1152" alt="screen shot 2018-06-22 at 3 04 51 pm" src="https://user-images.githubusercontent.com/1538216/41801149-b27880bc-762d-11e8-9f9c-1772ec613174.png">



Fixes https://github.com/ManageIQ/miq_v2v_ui_plugin/issues/422
https://bugzilla.redhat.com/show_bug.cgi?id=1594348