### PR TITLE
[#387] View Migrations when there are no infra mappings

### DIFF
--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -302,7 +302,7 @@ class Overview extends React.Component {
           }
           style={{ marginTop: 200 }}
         >
-          {transformationMappings.length > 0 && (
+          {(transformationMappings.length > 0 || transformationPlans.length > 0) && (
             <Migrations
               activeFilter={migrationsFilter}
               setActiveFilter={setMigrationsFilterAction}
@@ -354,6 +354,7 @@ class Overview extends React.Component {
               notStartedTransformationPlans={notStartedTransformationPlans}
               finishedWithErrorTransformationPlans={finishedWithErrorTransformationPlans}
               deleteInfrastructureMappingAction={deleteInfrastructureMappingAction}
+              migrationPlansExist={transformationPlans.length > 0 || archivedTransformationPlans.length > 0}
             />
           ) : (
             <OverviewEmptyState

--- a/app/javascript/react/screens/App/Overview/__test__/OverviewReducer.test.js
+++ b/app/javascript/react/screens/App/Overview/__test__/OverviewReducer.test.js
@@ -4,15 +4,20 @@ import { FETCH_V2V_TRANSFORMATION_PLANS, V2V_SET_MIGRATIONS_FILTER } from '../Ov
 import overviewReducer, { initialState } from '../OverviewReducer';
 import { transformationPlans } from '../overview.transformationPlans.fixtures';
 
+const initialStateWithInfraMapping = Immutable({
+  ...initialState,
+  transformationMappings: [{ id: '1' }]
+});
+
 describe('fetching transformation plans', () => {
   test('is pending', () => {
     const action = {
       type: `${FETCH_V2V_TRANSFORMATION_PLANS}_PENDING`
     };
-    const state = overviewReducer(initialState, action);
+    const state = overviewReducer(initialStateWithInfraMapping, action);
 
     expect(state).toEqual({
-      ...initialState,
+      ...initialStateWithInfraMapping,
       isFetchingTransformationPlans: true
     });
   });
@@ -26,7 +31,7 @@ describe('fetching transformation plans', () => {
       payload
     };
     const prevState = Immutable({
-      ...initialState,
+      ...initialStateWithInfraMapping,
       isFetchingTransformationPlans: true,
       isRejectedTransformationPlans: true,
       errorTransformationPlans: 'error'
@@ -34,7 +39,7 @@ describe('fetching transformation plans', () => {
     const state = overviewReducer(prevState, action);
 
     expect(state).toEqual({
-      ...initialState,
+      ...initialStateWithInfraMapping,
       transformationPlans: payload.data.resources
     });
   });
@@ -45,13 +50,13 @@ describe('fetching transformation plans', () => {
       payload: 'error'
     };
     const prevState = Immutable({
-      ...initialState,
+      ...initialStateWithInfraMapping,
       isFetchingTransformationPlans: true
     });
     const state = overviewReducer(prevState, action);
 
     expect(state).toEqual({
-      ...initialState,
+      ...initialStateWithInfraMapping,
       isRejectedTransformationPlans: true,
       errorTransformationPlans: 'error'
     });
@@ -64,7 +69,7 @@ test('sets the active migration filter', () => {
     type: V2V_SET_MIGRATIONS_FILTER,
     payload: activeFilter
   };
-  const state = overviewReducer(initialState, action);
+  const state = overviewReducer(initialStateWithInfraMapping, action);
 
   expect(state.migrationsFilter).toBe(activeFilter);
 });

--- a/app/javascript/react/screens/App/Overview/components/InfrastructureMappingsList/InfrastructureMappingsList.js
+++ b/app/javascript/react/screens/App/Overview/components/InfrastructureMappingsList/InfrastructureMappingsList.js
@@ -45,6 +45,7 @@ class InfrastructureMappingsList extends React.Component {
       transformationMappingsMutable: this.state.transformationMappingsMutable
     });
   };
+
   closeExpand = mapping => {
     mapping.expanded = false;
     this.setState({
@@ -52,13 +53,45 @@ class InfrastructureMappingsList extends React.Component {
     });
   };
 
+  renderEmptyState = ({ divider }) => (
+    <React.Fragment>
+      {divider && <hr className="infra-mapping-empty-state-divider" />}
+      <OverviewEmptyState
+        showWizardAction={this.props.createInfraMappingClick}
+        description={__('Create an infrastructure mapping to later be used by a migration plan')}
+        buttonText={__('Create Infrastructure Mapping')}
+      />
+    </React.Fragment>
+  );
+
+  renderHeadingWithLink = () => (
+    <div className="heading-with-link-container">
+      <div className="pull-left">
+        <h3>{__('Infrastructure Mappings')}</h3>
+      </div>
+      <div className="pull-right">
+        {/** todo: create IconLink in patternfly-react * */}
+        <a
+          href="#"
+          onClick={e => {
+            e.preventDefault();
+            this.props.createInfraMappingClick();
+          }}
+        >
+          <Icon type="pf" name="add-circle-o" />
+          {` `}
+          {__('Create Infrastructure Mapping')}
+        </a>
+      </div>
+    </div>
+  );
+
   render() {
     const {
       clusters,
       networks,
       datastores,
       error,
-      createInfraMappingClick,
       inProgressRequestsTransformationMappings,
       showDeleteConfirmationModalAction,
       setMappingToDeleteAction,
@@ -67,7 +100,8 @@ class InfrastructureMappingsList extends React.Component {
       mappingToDelete,
       yesToDeleteInfrastructureMappingAction,
       notStartedTransformationPlans,
-      finishedWithErrorTransformationPlans
+      finishedWithErrorTransformationPlans,
+      migrationPlansExist
     } = this.props;
 
     const { transformationMappingsMutable } = this.state;
@@ -83,26 +117,7 @@ class InfrastructureMappingsList extends React.Component {
         >
           {transformationMappingsMutable.length > 0 ? (
             <React.Fragment>
-              <div className="heading-with-link-container">
-                <div className="pull-left">
-                  <h3>{__('Infrastructure Mappings')}</h3>
-                </div>
-                <div className="pull-right">
-                  {/** todo: create IconLink in patternfly-react * */}
-                  <a
-                    href="#"
-                    onClick={e => {
-                      e.preventDefault();
-                      createInfraMappingClick();
-                    }}
-                  >
-                    <Icon type="pf" name="add-circle-o" />
-                    {` `}
-                    {__('Create Infrastructure Mapping')}
-                  </a>
-                </div>
-              </div>
-
+              {this.renderHeadingWithLink()}
               {error ? (
                 <OverviewEmptyState
                   title={__('Error loading mappings.')}
@@ -446,11 +461,10 @@ class InfrastructureMappingsList extends React.Component {
               )}
             </React.Fragment>
           ) : (
-            <OverviewEmptyState
-              showWizardAction={createInfraMappingClick}
-              description={__('Create an infrastructure mapping to later be used by a migration plan.')}
-              buttonText={__('Create Infrastructure Mapping')}
-            />
+            <React.Fragment>
+              {migrationPlansExist && this.renderHeadingWithLink()}
+              {this.renderEmptyState({ divider: migrationPlansExist })}
+            </React.Fragment>
           )}
         </Grid.Col>
         <DeleteInfrastructureMappingConfirmationModal
@@ -481,7 +495,8 @@ InfrastructureMappingsList.propTypes = {
   mappingToDelete: PropTypes.object,
   yesToDeleteInfrastructureMappingAction: PropTypes.func,
   notStartedTransformationPlans: PropTypes.array,
-  finishedWithErrorTransformationPlans: PropTypes.array
+  finishedWithErrorTransformationPlans: PropTypes.array,
+  migrationPlansExist: PropTypes.bool
 };
 
 export default InfrastructureMappingsList;

--- a/app/javascript/react/screens/App/Overview/components/InfrastructureMappingsList/InfrastructureMappingsList.scss
+++ b/app/javascript/react/screens/App/Overview/components/InfrastructureMappingsList/InfrastructureMappingsList.scss
@@ -107,3 +107,7 @@
     border: 1px solid $color-pf-blue-400;
   }
 }
+
+.infra-mapping-empty-state-divider {
+  border-top-color: $color-pf-black-300;
+}

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -251,9 +251,8 @@ class MigrationsCompletedList extends React.Component {
                         ]}
                         actions={
                           !archived && (
-                            <div
-                              onClick={e => e.stopPropagation()} // eslint-disable-line
-                            >
+                            // eslint-disable-next-line
+                            <div onClick={e => e.stopPropagation()}>
                               {failed && (
                                 <React.Fragment>
                                   <ScheduleMigrationButton

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -182,6 +182,8 @@ class MigrationsCompletedList extends React.Component {
                       onConfirm
                     };
 
+                    const isMissingMapping = !plan.infraMappingName;
+
                     return (
                       <ListView.Item
                         stacked
@@ -224,9 +226,15 @@ class MigrationsCompletedList extends React.Component {
                             {__('of')} &nbsp;<strong>{Object.keys(tasks).length} </strong>
                             {__('VMs successfully migrated.')}
                           </ListView.InfoItem>,
-                          <ListView.InfoItem key={`${plan.id}-infraMappingName`}>
-                            {plan.infraMappingName}
-                          </ListView.InfoItem>,
+                          plan.infraMappingName ? (
+                            <ListView.InfoItem key={`${plan.id}-infraMappingName`}>
+                              {plan.infraMappingName}
+                            </ListView.InfoItem>
+                          ) : (
+                            <ListView.InfoItem key={`${plan.id}-infraMappingWarning`}>
+                              <Icon type="pf" name="warning-triangle-o" /> {__('Infrastructure mapping does not exist')}
+                            </ListView.InfoItem>
+                          ),
                           <ListView.InfoItem key={`${plan.id}-elapsed`}>
                             <ListView.Icon type="fa" size="lg" name="clock-o" />
                             {elapsedTime}
@@ -243,7 +251,8 @@ class MigrationsCompletedList extends React.Component {
                         ]}
                         actions={
                           !archived && (
-                            <div onClick={e => e.stopPropagation()} // eslint-disable-line
+                            <div
+                              onClick={e => e.stopPropagation()} // eslint-disable-line
                             >
                               {failed && (
                                 <React.Fragment>
@@ -256,13 +265,14 @@ class MigrationsCompletedList extends React.Component {
                                     fetchTransformationPlansAction={fetchTransformationPlansAction}
                                     fetchTransformationPlansUrl={fetchTransformationPlansUrl}
                                     plan={plan}
+                                    isMissingMapping={isMissingMapping}
                                   />
                                   <Button
                                     onClick={e => {
                                       e.stopPropagation();
                                       retryClick(plan.href, plan.id);
                                     }}
-                                    disabled={loading === plan.href}
+                                    disabled={isMissingMapping || loading === plan.href}
                                   >
                                     {__('Retry')}
                                   </Button>

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -84,6 +84,7 @@ class MigrationsNotStartedList extends React.Component {
                 <ListView className="plans-not-started-list" style={{ marginTop: 0 }}>
                   {sortedMigrations.map(plan => {
                     const migrationScheduled = plan.schedules && plan.schedules[0].run_at.start_time;
+                    const isMissingMapping = !plan.infraMappingName;
 
                     return (
                       <ListView.Item
@@ -103,6 +104,7 @@ class MigrationsNotStartedList extends React.Component {
                               fetchTransformationPlansAction={fetchTransformationPlansAction}
                               fetchTransformationPlansUrl={fetchTransformationPlansUrl}
                               plan={plan}
+                              isMissingMapping={isMissingMapping}
                             />
                             <Button
                               id={`migrate_${plan.id}`}
@@ -110,7 +112,7 @@ class MigrationsNotStartedList extends React.Component {
                                 e.stopPropagation();
                                 migrateClick(plan.href);
                               }}
-                              disabled={loading === plan.href || plan.schedule_type}
+                              disabled={isMissingMapping || loading === plan.href || plan.schedule_type}
                             >
                               {__('Migrate')}
                             </Button>
@@ -128,9 +130,15 @@ class MigrationsNotStartedList extends React.Component {
                             <Icon type="pf" name="virtual-machine" />
                             <strong>{plan.options.config_info.actions.length}</strong> {__('VMs')}
                           </ListView.InfoItem>,
-                          <ListView.InfoItem key={`${plan.id}-infraMappingName`}>
-                            {plan.infraMappingName}
-                          </ListView.InfoItem>,
+                          isMissingMapping ? (
+                            <ListView.InfoItem key={`${plan.id}-infraMappingWarning`}>
+                              <Icon type="pf" name="warning-triangle-o" /> {__('Infrastucture mapping does not exist.')}
+                            </ListView.InfoItem>
+                          ) : (
+                            <ListView.InfoItem key={`${plan.id}-infraMappingName`}>
+                              {plan.infraMappingName}
+                            </ListView.InfoItem>
+                          ),
                           migrationScheduled && (
                             <ListView.InfoItem key={plan.id + 1} style={{ textAlign: 'left' }}>
                               <Icon type="fa" name="clock-o" />

--- a/app/javascript/react/screens/App/Overview/components/Migrations/ScheduleMigrationButton.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/ScheduleMigrationButton.js
@@ -11,7 +11,8 @@ const ScheduleMigrationButton = ({
   scheduleMigration,
   fetchTransformationPlansAction,
   fetchTransformationPlansUrl,
-  plan
+  plan,
+  isMissingMapping
 }) => {
   const migrationScheduled = plan.schedules && plan.schedules[0].run_at.start_time;
   const staleMigrationSchedule = (new Date(migrationScheduled).getTime() || 0) < Date.now();
@@ -55,7 +56,7 @@ const ScheduleMigrationButton = ({
             e.stopPropagation();
             toggleScheduleMigrationModal({ plan });
           }}
-          disabled={loading === plan.href || plan.schedule_type}
+          disabled={isMissingMapping || loading === plan.href || plan.schedule_type}
         >
           {__('Schedule')}
         </Button>
@@ -71,7 +72,7 @@ const ScheduleMigrationButton = ({
               onConfirm
             });
           }}
-          disabled={loading === plan.href}
+          disabled={isMissingMapping || loading === plan.href}
         >
           {__('Unschedule')}
         </Button>
@@ -88,7 +89,8 @@ ScheduleMigrationButton.propTypes = {
   scheduleMigration: PropTypes.func,
   fetchTransformationPlansAction: PropTypes.func,
   fetchTransformationPlansUrl: PropTypes.string,
-  plan: PropTypes.object
+  plan: PropTypes.object,
+  isMissingMapping: PropTypes.bool
 };
 
 export default ScheduleMigrationButton;

--- a/app/javascript/react/screens/App/Overview/components/Migrations/__test__/MigrationsCompletedList.test.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/__test__/MigrationsCompletedList.test.js
@@ -7,7 +7,10 @@ import { allRequestsWithTasks } from '../../../overview.requestWithTasks.fixture
 import MigrationsCompletedList from '../MigrationsCompletedList';
 
 const [, , , finishedPlanOne, finishedPlanTwo] = transformationPlans.resources;
-const finishedTransformationPlans = [finishedPlanOne, finishedPlanTwo];
+const finishedTransformationPlans = [
+  Immutable({ ...finishedPlanOne, infraMappingName: 'Infrastructure Mapping' }),
+  Immutable({ ...finishedPlanTwo, infraMappingName: 'Infrastructure Mapping' })
+];
 const { results: requestsWithTasks } = allRequestsWithTasks;
 
 describe('when displaying archived migration plans', () => {

--- a/app/javascript/react/screens/App/Overview/overview.transformationPlans.fixtures.js
+++ b/app/javascript/react/screens/App/Overview/overview.transformationPlans.fixtures.js
@@ -21,7 +21,6 @@ export const transformationPlans = Immutable({
       id: '10',
       miq_requests: [],
       configVmLength: 2,
-      infraMappingName: null,
       scheduleTime: null,
       status: null
     },
@@ -73,7 +72,6 @@ export const transformationPlans = Immutable({
         }
       ],
       configVmLength: 2,
-      infraMappingName: null,
       scheduleTime: null,
       status: 'Ok'
     },
@@ -163,7 +161,6 @@ export const transformationPlans = Immutable({
         }
       ],
       configVmLength: 2,
-      infraMappingName: null,
       scheduleTime: null,
       status: 'Ok'
     },
@@ -218,7 +215,6 @@ export const transformationPlans = Immutable({
         }
       ],
       configVmLength: 2,
-      infraMappingName: null,
       scheduleTime: null,
       status: 'Error'
     },
@@ -273,7 +269,6 @@ export const transformationPlans = Immutable({
         }
       ],
       configVmLength: 2,
-      infraMappingName: null,
       scheduleTime: null,
       status: 'Ok'
     },
@@ -328,7 +323,6 @@ export const transformationPlans = Immutable({
         }
       ],
       configVmLength: 2,
-      infraMappingName: null,
       scheduleTime: null,
       status: 'Ok'
     }


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/miq_v2v_ui_plugin/issues/387
Fixes https://github.com/ManageIQ/miq_v2v_ui_plugin/issues/357

* If transformation plans exist, but all mappings have been deleted,
  still show the Migrations section, but display an empty state in the
  Infrastructure Mappings section
* Disable `schedule` and `retry` buttons for orphaned Not Started Plans
* Disable `retry` button for orphaned (failed) Completed Plans

## Screens
### All Mappings have been deleted, but Not Started Plans exist
![all_mappings_deleted](https://user-images.githubusercontent.com/15141412/43202524-c034c168-8fe9-11e8-9f13-276fc6d486fb.png)

### The Mapping for a Not Started Plan has been deleted
![buttons](https://user-images.githubusercontent.com/15141412/43202601-ea4432ea-8fe9-11e8-8ba1-7cc6eac2d488.png)

### All Mappings have been deleted, but Completed Plans exist
![completed_plans](https://user-images.githubusercontent.com/15141412/43202782-62d65238-8fea-11e8-8731-b7d48e185b90.png)

### The Mapping for a Completed Plan has been deleted
![fullscreen_7_25_18__9_15_am](https://user-images.githubusercontent.com/15141412/43203189-7ed4027c-8feb-11e8-9efb-edf3bafacc1f.png)

