### PR TITLE
VMs in conflict could be valid hence make them selectable with a warning

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepConstants.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepConstants.js
@@ -9,5 +9,6 @@ export const V2V_VM_POST_VALIDATION_REASONS = {
   not_exist: __('VM does not exist'),
   ok: __('VM available for migration'),
   duplicate: __('Duplicate VM'),
+  inactive: __('VM is inactive'),
   no_info_available: __('VM unavailable for migration, no information available')
 };

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepReducer.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepReducer.js
@@ -72,14 +72,19 @@ const _formatInvalidVms = vms => {
   );
 };
 
-const _formatConflictVms = vms =>
-  vms &&
-  vms.map(v => {
-    v.conflict = true;
-    v.allocated_size = numeral(v.allocated_size).format('0.00b');
-    v.reason = V2V_VM_POST_VALIDATION_REASONS[v.reason];
-    return v;
-  });
+const _formatConflictVms = vms => {
+  const uniqueIds = vms && [...new Set(vms.map(value => value.id))];
+  return (
+    vms &&
+    vms.map((v, vIndex) => {
+      v.warning = true; // although in conflict, the VMs could be valid - hence display a warning and allow select
+      v.allocated_size = numeral(v.allocated_size).format('0.00b');
+      v.reason = V2V_VM_POST_VALIDATION_REASONS[v.reason];
+      manageOddCSVImportErrors(v, vIndex, uniqueIds);
+      return v;
+    })
+  );
+};
 
 export default (state = initialState, action) => {
   switch (action.type) {

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepReducer.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepReducer.js
@@ -73,13 +73,26 @@ const _formatInvalidVms = vms => {
 };
 
 const _formatConflictVms = vms => {
+  const inactiveVM = vms && vms.filter(vm => vm.cluster === '' || vm.path === '');
+  const inactiveVMCount = inactiveVM.length;
+  const vmCount = inactiveVMCount > 0 ? vms.length - inactiveVMCount : vms.length;
   const uniqueIds = vms && [...new Set(vms.map(value => value.id))];
   return (
     vms &&
     vms.map((v, vIndex) => {
-      v.warning = true; // although in conflict, the VMs could be valid - hence display a warning and allow select
       v.allocated_size = numeral(v.allocated_size).format('0.00b');
       v.reason = V2V_VM_POST_VALIDATION_REASONS[v.reason];
+
+      if (v.cluster === '' || v.path === '') {
+        v.reason = V2V_VM_POST_VALIDATION_REASONS.inactive;
+        v.invalid = true;
+      } else if (vmCount === 1) {
+        v.reason = V2V_VM_POST_VALIDATION_REASONS.ok;
+        v.valid = true;
+      } else if (vmCount > 1) {
+        v.warning = true;
+      }
+
       manageOddCSVImportErrors(v, vIndex, uniqueIds);
       return v;
     })


### PR DESCRIPTION
I encountered this use case while testing PR https://github.com/ManageIQ/manageiq/pull/17650 where my CSV file had a VM name specified like that -

```
Name
cu-24x7
```
There were no Providers/Clusters specified.

After CSV validation, the output was 2 conflicted VMs. 
These VMs were reprocessed to identify valid VMs, invalid (inactive) VMs and conflict VMs

<img width="877" alt="screen shot 2018-06-29 at 12 46 53 pm" src="https://user-images.githubusercontent.com/1538216/42111812-89e96bc6-7b9a-11e8-8f90-aef578483c63.png">

<img width="853" alt="screen shot 2018-06-29 at 12 38 28 pm" src="https://user-images.githubusercontent.com/1538216/42111469-71854cae-7b99-11e8-8535-d7fb95d8fbb7.png">




Other than the above change, I also added the logic to `manageOddCSVImportErrors` in the function that handles conflicted VMs

https://bugzilla.redhat.com/show_bug.cgi?id=1596318

Depends on: ManageIQ/manageiq#17650 

