### PR TITLE
[#424] schema validators for Overview screen

### DIFF
--- a/app/javascript/common/schemaHelpers.js
+++ b/app/javascript/common/schemaHelpers.js
@@ -1,3 +1,0 @@
-export const logSchemaError = err => {
-  console.error(err.name, err.errors); // eslint-disable-line no-console
-};

--- a/app/javascript/common/schemaHelpers.js
+++ b/app/javascript/common/schemaHelpers.js
@@ -1,0 +1,3 @@
+export const logSchemaError = err => {
+  console.error(err.name, err.errors); // eslint-disable-line no-console
+};

--- a/app/javascript/data/models/clusters.js
+++ b/app/javascript/data/models/clusters.js
@@ -1,0 +1,19 @@
+import { array, string, object } from 'yup';
+
+export const clustersSchema = array()
+  .of(
+    object().shape({
+      href: string().required(),
+      id: string().required(),
+      ems_id: string().required(),
+      uid_ems: string().required(),
+      ext_management_system: object()
+        .shape({
+          emstype: string().required(),
+          name: string().required()
+        })
+        .required(),
+      v_parent_datacenter: string().required()
+    })
+  )
+  .nullable();

--- a/app/javascript/data/models/clusters.js
+++ b/app/javascript/data/models/clusters.js
@@ -13,7 +13,7 @@ export const clustersSchema = array()
           name: string().required()
         })
         .required(),
-      v_parent_datacenter: string().required()
+      v_parent_datacenter: string().nullable()
     })
   )
   .nullable();

--- a/app/javascript/data/models/datastores.js
+++ b/app/javascript/data/models/datastores.js
@@ -1,0 +1,10 @@
+import { array, string, object } from 'yup';
+
+export const datastoresSchema = array()
+  .of(
+    object().shape({
+      href: string().required(),
+      id: string().required()
+    })
+  )
+  .nullable();

--- a/app/javascript/data/models/networks.js
+++ b/app/javascript/data/models/networks.js
@@ -1,0 +1,13 @@
+import { array, string, object } from 'yup';
+
+export const networksSchema = array()
+  .of(
+    object().shape({
+      href: string().required(),
+      id: string().required(),
+      switch_id: string().required(),
+      name: string().required(),
+      uid_ems: string().required()
+    })
+  )
+  .nullable();

--- a/app/javascript/data/models/plans.js
+++ b/app/javascript/data/models/plans.js
@@ -1,0 +1,43 @@
+import { array, string, object } from 'yup';
+
+export const plansSchema = array()
+  .of(
+    object().shape({
+      href: string().required(),
+      id: string().required(),
+      name: string().required(),
+      description: string().nullable(),
+      options: object()
+        .shape({
+          config_info: object().shape({
+            transformation_mapping_id: string().required(),
+            vm_ids: array()
+              .of(string())
+              .required()
+          })
+        })
+        .required(),
+      created_at: string().required(),
+      miq_requests: array()
+        .of(
+          object().shape({
+            href: string().required(),
+            id: string().required(),
+            description: string().required(),
+            created_on: string().required(),
+            updated_on: string().nullable(),
+            fulfilled_on: string().nullable(),
+            request_state: string().required(),
+            status: string().required(),
+            options: object()
+              .shape({
+                src_id: string(),
+                delivered_on: string().nullable()
+              })
+              .required()
+          })
+        )
+        .nullable()
+    })
+  )
+  .nullable();

--- a/app/javascript/data/models/provider.js
+++ b/app/javascript/data/models/provider.js
@@ -1,0 +1,11 @@
+import { array, string, object } from 'yup';
+
+export const providersSchema = array()
+  .of(
+    object().shape({
+      href: string().required(),
+      type: string().required(),
+      id: string().required()
+    })
+  )
+  .nullable();

--- a/app/javascript/data/models/requests.js
+++ b/app/javascript/data/models/requests.js
@@ -1,0 +1,43 @@
+import { array, string, object } from 'yup';
+
+export const requestsSchema = array()
+  .of(
+    object().shape({
+      href: string().required(),
+      id: string().required(),
+      description: string().nullable(),
+      approval_state: string().nullable(),
+      created_on: string().required(),
+      updated_on: string().nullable(),
+      fulfilled_on: string().nullable(),
+      request_state: string().nullable(),
+      status: string(),
+      options: object()
+        .shape({
+          delivered_on: string()
+        })
+        .required(),
+      miq_request_tasks: array()
+        .of(
+          object().shape({
+            href: string().required(),
+            id: string().required(),
+            description: string().required(),
+            state: string().required(),
+            options: object()
+              .shape({
+                src_id: string(),
+                delivered_on: string().nullable(),
+                transformation_host_name: string().nullable()
+              })
+              .required(),
+            created_on: string().required(),
+            updated_on: string().nullable(),
+            message: string().required(),
+            status: string().required()
+          })
+        )
+        .nullable()
+    })
+  )
+  .nullable();

--- a/app/javascript/data/models/transformationMappings.js
+++ b/app/javascript/data/models/transformationMappings.js
@@ -1,0 +1,32 @@
+import { array, string, object } from 'yup';
+
+export const mappingsSchema = array()
+  .of(
+    object().shape({
+      href: string().required(),
+      id: string().required(),
+      name: string().required(),
+      created_at: string().required(),
+      service_templates: array()
+        .of(
+          object().shape({
+            id: string().required(),
+            name: string().required()
+          })
+        )
+        .nullable(),
+      transformation_mapping_items: array()
+        .of(
+          object().shape({
+            id: string().required(),
+            source_id: string().required(),
+            source_type: string().required(),
+            destination_id: string().required(),
+            destination_type: string().required(),
+            transformation_mapping_id: string().required()
+          })
+        )
+        .required()
+    })
+  )
+  .nullable();

--- a/app/javascript/data/schemaHelpers.js
+++ b/app/javascript/data/schemaHelpers.js
@@ -1,0 +1,13 @@
+export const schemaValidationEnabled = true;
+
+export const logSchemaError = err => {
+  console.error(err.name, err.errors); // eslint-disable-line no-console
+};
+
+export const validateSchema = (schema, models) => {
+  if (schemaValidationEnabled) {
+    schema.validate(models, { abortEarly: false, strict: true }).catch(err => {
+      logSchemaError(err);
+    });
+  }
+};

--- a/app/javascript/packs/migration.js
+++ b/app/javascript/packs/migration.js
@@ -1,3 +1,4 @@
+import './polyfills';
 import componentRegistry from '../components/componentRegistry';
 import { coreComponents } from '../components';
 import { mount } from '../components/mounter';

--- a/app/javascript/packs/polyfills.js
+++ b/app/javascript/packs/polyfills.js
@@ -1,0 +1,6 @@
+/**
+ * V2V Plugin polyfills
+ */
+import 'core-js/es6/promise';
+import 'core-js/es6/set';
+import 'core-js/es6/map';

--- a/app/javascript/react/screens/App/Overview/OverviewReducer.js
+++ b/app/javascript/react/screens/App/Overview/OverviewReducer.js
@@ -1,13 +1,13 @@
 import Immutable from 'seamless-immutable';
 
 import {
-  validateProviders,
-  validateClusters,
-  validateNetworks,
-  validateDatastores,
-  validateTransformationMappings,
-  validatePlans,
-  validateRequests
+  validateOverviewClusters,
+  validateOverviewDatastores,
+  validateOverviewNetworks,
+  validateOverviewPlans,
+  validateOverviewProviders,
+  validateOverviewRequests,
+  validateOverviewMappings
 } from './OverviewValidators';
 
 import {
@@ -143,7 +143,7 @@ export default (state = initialState, action) => {
           return insufficient;
         }
         const providers = action.payload.data.resources;
-        validateProviders(providers);
+        validateOverviewProviders(providers);
         // Providers are sufficient if Vmware and Redhat providers are both present.
         const sufficient =
           providers.some(
@@ -163,7 +163,7 @@ export default (state = initialState, action) => {
       return state.set('isFetchingTransformationMappings', true);
     case `${FETCH_V2V_TRANSFORMATION_MAPPINGS}_FULFILLED`:
       if (action.payload.data && action.payload.data.resources) {
-        validateTransformationMappings(action.payload.data.resources);
+        validateOverviewMappings(action.payload.data.resources);
         return state
           .set('transformationMappings', action.payload.data.resources)
           .set('isRejectedTransformationMappings', false)
@@ -183,7 +183,7 @@ export default (state = initialState, action) => {
     case `${FETCH_V2V_TRANSFORMATION_PLANS}_PENDING`:
       return state.set('isFetchingTransformationPlans', true);
     case `${FETCH_V2V_TRANSFORMATION_PLANS}_FULFILLED`:
-      validatePlans(action.payload.data.resources);
+      validateOverviewPlans(action.payload.data.resources);
       return state
         .set('transformationPlans', action.payload.data.resources)
         .set('isFetchingTransformationPlans', false)
@@ -199,7 +199,7 @@ export default (state = initialState, action) => {
         .set('isFetchingArchivedTransformationPlans', 'true')
         .set('isRejectedArchivedTransformationPlans', false);
     case `${FETCH_V2V_ARCHIVED_TRANSFORMATION_PLANS}_FULFILLED`:
-      validatePlans(action.payload.data.resources);
+      validateOverviewPlans(action.payload.data.resources);
       return state
         .set('archivedTransformationPlans', action.payload.data.resources)
         .set('isFetchingArchivedTransformationPlans', '')
@@ -213,7 +213,7 @@ export default (state = initialState, action) => {
     case `${FETCH_V2V_ALL_REQUESTS_WITH_TASKS}_PENDING`:
       return state.set('isFetchingAllRequestsWithTasks', true);
     case `${FETCH_V2V_ALL_REQUESTS_WITH_TASKS}_FULFILLED`:
-      validateRequests(action.payload.data.results);
+      validateOverviewRequests(action.payload.data.results);
       return state
         .set('allRequestsWithTasks', action.payload.data.results)
         .set('isFetchingAllRequestsWithTasks', false)
@@ -233,7 +233,7 @@ export default (state = initialState, action) => {
         .set('isFetchingAllArchivedPlanRequestsWithTasks', true)
         .set('isRejectedAllArchivedPlanRequestsWithTasks', false);
     case `${FETCH_V2V_ALL_ARCHIVED_PLAN_REQUESTS_WITH_TASKS}_FULFILLED`:
-      validateRequests(action.payload.data.results);
+      validateOverviewRequests(action.payload.data.results);
       return state
         .set('allArchivedPlanRequestsWithTasks', action.payload.data.results)
         .set('isFetchingAllArchivedPlanRequestsWithTasks', false)
@@ -247,7 +247,7 @@ export default (state = initialState, action) => {
     case `${V2V_FETCH_CLUSTERS}_PENDING`:
       return state.set('isFetchingClusters', true);
     case `${V2V_FETCH_CLUSTERS}_FULFILLED`:
-      validateClusters(action.payload.data.resources);
+      validateOverviewClusters(action.payload.data.resources);
       return state
         .set('clusters', action.payload.data.resources)
         .set('isFetchingClusters', false)
@@ -261,7 +261,7 @@ export default (state = initialState, action) => {
     case `${FETCH_NETWORKS}_PENDING`:
       return state.set('isFetchingNetworks', true);
     case `${FETCH_NETWORKS}_FULFILLED`:
-      validateNetworks(action.payload.data.resources);
+      validateOverviewNetworks(action.payload.data.resources);
       return state
         .set('networks', action.payload.data.resources)
         .set('isFetchingNetworks', false)
@@ -275,7 +275,7 @@ export default (state = initialState, action) => {
     case `${FETCH_DATASTORES}_PENDING`:
       return state.set('isFetchingDatastores', true);
     case `${FETCH_DATASTORES}_FULFILLED`:
-      validateDatastores(action.payload.data.resources);
+      validateOverviewDatastores(action.payload.data.resources);
       return state
         .set('datastores', action.payload.data.resources)
         .set('isFetchingDatastores', false)

--- a/app/javascript/react/screens/App/Overview/OverviewReducer.js
+++ b/app/javascript/react/screens/App/Overview/OverviewReducer.js
@@ -1,6 +1,16 @@
 import Immutable from 'seamless-immutable';
 
 import {
+  validateProviders,
+  validateClusters,
+  validateNetworks,
+  validateDatastores,
+  validateTransformationMappings,
+  validatePlans,
+  validateRequests
+} from './OverviewValidators';
+
+import {
   SHOW_MAPPING_WIZARD,
   HIDE_MAPPING_WIZARD,
   MAPPING_WIZARD_EXITED,
@@ -133,6 +143,7 @@ export default (state = initialState, action) => {
           return insufficient;
         }
         const providers = action.payload.data.resources;
+        validateProviders(providers);
         // Providers are sufficient if Vmware and Redhat providers are both present.
         const sufficient =
           providers.some(
@@ -152,6 +163,7 @@ export default (state = initialState, action) => {
       return state.set('isFetchingTransformationMappings', true);
     case `${FETCH_V2V_TRANSFORMATION_MAPPINGS}_FULFILLED`:
       if (action.payload.data && action.payload.data.resources) {
+        validateTransformationMappings(action.payload.data.resources);
         return state
           .set('transformationMappings', action.payload.data.resources)
           .set('isRejectedTransformationMappings', false)
@@ -171,6 +183,7 @@ export default (state = initialState, action) => {
     case `${FETCH_V2V_TRANSFORMATION_PLANS}_PENDING`:
       return state.set('isFetchingTransformationPlans', true);
     case `${FETCH_V2V_TRANSFORMATION_PLANS}_FULFILLED`:
+      validatePlans(action.payload.data.resources);
       return state
         .set('transformationPlans', action.payload.data.resources)
         .set('isFetchingTransformationPlans', false)
@@ -186,6 +199,7 @@ export default (state = initialState, action) => {
         .set('isFetchingArchivedTransformationPlans', 'true')
         .set('isRejectedArchivedTransformationPlans', false);
     case `${FETCH_V2V_ARCHIVED_TRANSFORMATION_PLANS}_FULFILLED`:
+      validatePlans(action.payload.data.resources);
       return state
         .set('archivedTransformationPlans', action.payload.data.resources)
         .set('isFetchingArchivedTransformationPlans', '')
@@ -199,6 +213,7 @@ export default (state = initialState, action) => {
     case `${FETCH_V2V_ALL_REQUESTS_WITH_TASKS}_PENDING`:
       return state.set('isFetchingAllRequestsWithTasks', true);
     case `${FETCH_V2V_ALL_REQUESTS_WITH_TASKS}_FULFILLED`:
+      validateRequests(action.payload.data.results);
       return state
         .set('allRequestsWithTasks', action.payload.data.results)
         .set('isFetchingAllRequestsWithTasks', false)
@@ -218,6 +233,7 @@ export default (state = initialState, action) => {
         .set('isFetchingAllArchivedPlanRequestsWithTasks', true)
         .set('isRejectedAllArchivedPlanRequestsWithTasks', false);
     case `${FETCH_V2V_ALL_ARCHIVED_PLAN_REQUESTS_WITH_TASKS}_FULFILLED`:
+      validateRequests(action.payload.data.results);
       return state
         .set('allArchivedPlanRequestsWithTasks', action.payload.data.results)
         .set('isFetchingAllArchivedPlanRequestsWithTasks', false)
@@ -231,6 +247,7 @@ export default (state = initialState, action) => {
     case `${V2V_FETCH_CLUSTERS}_PENDING`:
       return state.set('isFetchingClusters', true);
     case `${V2V_FETCH_CLUSTERS}_FULFILLED`:
+      validateClusters(action.payload.data.resources);
       return state
         .set('clusters', action.payload.data.resources)
         .set('isFetchingClusters', false)
@@ -244,6 +261,7 @@ export default (state = initialState, action) => {
     case `${FETCH_NETWORKS}_PENDING`:
       return state.set('isFetchingNetworks', true);
     case `${FETCH_NETWORKS}_FULFILLED`:
+      validateNetworks(action.payload.data.resources);
       return state
         .set('networks', action.payload.data.resources)
         .set('isFetchingNetworks', false)
@@ -257,6 +275,7 @@ export default (state = initialState, action) => {
     case `${FETCH_DATASTORES}_PENDING`:
       return state.set('isFetchingDatastores', true);
     case `${FETCH_DATASTORES}_FULFILLED`:
+      validateDatastores(action.payload.data.resources);
       return state
         .set('datastores', action.payload.data.resources)
         .set('isFetchingDatastores', false)

--- a/app/javascript/react/screens/App/Overview/OverviewValidators.js
+++ b/app/javascript/react/screens/App/Overview/OverviewValidators.js
@@ -1,222 +1,36 @@
-import { array, string, object } from 'yup';
-import { logSchemaError } from '../../../../common/schemaHelpers';
+import { validateSchema } from '../../../../data/schemaHelpers';
+import { clustersSchema } from '../../../../data/models/clusters';
+import { datastoresSchema } from '../../../../data/models/datastores';
+import { networksSchema } from '../../../../data/models/networks';
+import { plansSchema } from '../../../../data/models/plans';
+import { providersSchema } from '../../../../data/models/provider';
+import { requestsSchema } from '../../../../data/models/requests';
+import { mappingsSchema } from '../../../../data/models/transformationMappings';
 
-const providersSchema = array()
-  .of(
-    object().shape({
-      href: string().required(),
-      type: string().required(),
-      id: string().required()
-    })
-  )
-  .nullable();
-
-export const validateProviders = providers => {
-  providersSchema
-    .validate(providers, { abortEarly: false, strict: true })
-    .catch(err => {
-      logSchemaError(err);
-    });
+export const validateOverviewClusters = clusters => {
+  validateSchema(clustersSchema, clusters);
 };
 
-const clustersSchema = array()
-  .of(
-    object().shape({
-      href: string().required(),
-      id: string().required(),
-      ems_id: string().required(),
-      uid_ems: string().required(),
-      ext_management_system: object()
-        .shape({
-          emstype: string().required(),
-          name: string().required()
-        })
-        .required(),
-      v_parent_datacenter: string().required()
-    })
-  )
-  .nullable();
-
-export const validateClusters = clusters => {
-  clustersSchema
-    .validate(clusters, { abortEarly: false, strict: true })
-    .catch(err => {
-      logSchemaError(err);
-    });
+export const validateOverviewDatastores = datastores => {
+  validateSchema(datastoresSchema, datastores);
 };
 
-const networksSchema = array()
-  .of(
-    object().shape({
-      href: string().required(),
-      id: string().required(),
-      switch_id: string().required(),
-      name: string().required(),
-      uid_ems: string().required()
-    })
-  )
-  .nullable();
-
-export const validateNetworks = networks => {
-  networksSchema
-    .validate(networks, { abortEarly: false, strict: true })
-    .catch(err => {
-      logSchemaError(err);
-    });
+export const validateOverviewNetworks = networks => {
+  validateSchema(networksSchema, networks);
 };
 
-const datastoresSchema = array()
-  .of(
-    object().shape({
-      href: string().required(),
-      id: string().required()
-    })
-  )
-  .nullable();
-
-export const validateDatastores = datastores => {
-  datastoresSchema
-    .validate(datastores, { abortEarly: false, strict: true })
-    .catch(err => {
-      logSchemaError(err);
-    });
+export const validateOverviewPlans = plans => {
+  validateSchema(plansSchema, plans);
 };
 
-const mappingsSchema = array()
-  .of(
-    object().shape({
-      href: string().required(),
-      id: string().required(),
-      name: string().required(),
-      created_at: string().required(),
-      service_templates: array()
-        .of(
-          object().shape({
-            id: string().required(),
-            name: string().required()
-          })
-        )
-        .nullable(),
-      transformation_mapping_items: array()
-        .of(
-          object().shape({
-            id: string().required(),
-            source_id: string().required(),
-            source_type: string().required(),
-            destination_id: string().required(),
-            destination_type: string().required(),
-            transformation_mapping_id: string().required()
-          })
-        )
-        .required()
-    })
-  )
-  .nullable();
-
-export const validateTransformationMappings = mappings => {
-  mappingsSchema
-    .validate(mappings, { abortEarly: false, strict: true })
-    .catch(err => {
-      logSchemaError(err);
-    });
+export const validateOverviewProviders = providers => {
+  validateSchema(providersSchema, providers);
 };
 
-const plansSchema = array()
-  .of(
-    object().shape({
-      href: string().required(),
-      id: string().required(),
-      name: string().required(),
-      description: string().nullable(),
-      options: object()
-        .shape({
-          config_info: object().shape({
-            transformation_mapping_id: string().required(),
-            vm_ids: array()
-              .of(string())
-              .required()
-          })
-        })
-        .required(),
-      created_at: string().required(),
-      miq_requests: array()
-        .of(
-          object().shape({
-            href: string().required(),
-            id: string().required(),
-            description: string().required(),
-            created_on: string().required(),
-            updated_on: string().nullable(),
-            fulfilled_on: string().nullable(),
-            request_state: string().required(),
-            status: string().required(),
-            options: object()
-              .shape({
-                src_id: string(),
-                delivered_on: string().nullable()
-              })
-              .required()
-          })
-        )
-        .nullable()
-    })
-  )
-  .nullable();
-
-export const validatePlans = plans => {
-  plansSchema
-    .validate(plans, { abortEarly: false, strict: true })
-    .catch(err => {
-      logSchemaError(err);
-    });
+export const validateOverviewRequests = requests => {
+  validateSchema(requestsSchema, requests);
 };
 
-const requestsSchema = array()
-  .of(
-    object().shape({
-      href: string().required(),
-      id: string().required(),
-      description: string().nullable(),
-      approval_state: string().nullable(),
-      created_on: string().required(),
-      updated_on: string().nullable(),
-      fulfilled_on: string().nullable(),
-      request_state: string().nullable(),
-      status: string(),
-      options: object()
-        .shape({
-          delivered_on: string()
-        })
-        .required(),
-      miq_request_tasks: array()
-        .of(
-          object().shape({
-            href: string().required(),
-            id: string().required(),
-            description: string().required(),
-            state: string().required(),
-            options: object()
-              .shape({
-                src_id: string(),
-                delivered_on: string().nullable(),
-                transformation_host_name: string().nullable()
-              })
-              .required(),
-            created_on: string().required(),
-            updated_on: string().nullable(),
-            message: string().required(),
-            status: string().required()
-          })
-        )
-        .nullable()
-    })
-  )
-  .nullable();
-
-export const validateRequests = requests => {
-  requestsSchema
-    .validate(requests, { abortEarly: false, strict: true })
-    .catch(err => {
-      logSchemaError(err);
-    });
+export const validateOverviewMappings = mappings => {
+  validateSchema(mappingsSchema, mappings);
 };

--- a/app/javascript/react/screens/App/Overview/OverviewValidators.js
+++ b/app/javascript/react/screens/App/Overview/OverviewValidators.js
@@ -1,0 +1,222 @@
+import { array, string, object } from 'yup';
+import { logSchemaError } from '../../../../common/schemaHelpers';
+
+const providersSchema = array()
+  .of(
+    object().shape({
+      href: string().required(),
+      type: string().required(),
+      id: string().required()
+    })
+  )
+  .nullable();
+
+export const validateProviders = providers => {
+  providersSchema
+    .validate(providers, { abortEarly: false, strict: true })
+    .catch(err => {
+      logSchemaError(err);
+    });
+};
+
+const clustersSchema = array()
+  .of(
+    object().shape({
+      href: string().required(),
+      id: string().required(),
+      ems_id: string().required(),
+      uid_ems: string().required(),
+      ext_management_system: object()
+        .shape({
+          emstype: string().required(),
+          name: string().required()
+        })
+        .required(),
+      v_parent_datacenter: string().required()
+    })
+  )
+  .nullable();
+
+export const validateClusters = clusters => {
+  clustersSchema
+    .validate(clusters, { abortEarly: false, strict: true })
+    .catch(err => {
+      logSchemaError(err);
+    });
+};
+
+const networksSchema = array()
+  .of(
+    object().shape({
+      href: string().required(),
+      id: string().required(),
+      switch_id: string().required(),
+      name: string().required(),
+      uid_ems: string().required()
+    })
+  )
+  .nullable();
+
+export const validateNetworks = networks => {
+  networksSchema
+    .validate(networks, { abortEarly: false, strict: true })
+    .catch(err => {
+      logSchemaError(err);
+    });
+};
+
+const datastoresSchema = array()
+  .of(
+    object().shape({
+      href: string().required(),
+      id: string().required()
+    })
+  )
+  .nullable();
+
+export const validateDatastores = datastores => {
+  datastoresSchema
+    .validate(datastores, { abortEarly: false, strict: true })
+    .catch(err => {
+      logSchemaError(err);
+    });
+};
+
+const mappingsSchema = array()
+  .of(
+    object().shape({
+      href: string().required(),
+      id: string().required(),
+      name: string().required(),
+      created_at: string().required(),
+      service_templates: array()
+        .of(
+          object().shape({
+            id: string().required(),
+            name: string().required()
+          })
+        )
+        .nullable(),
+      transformation_mapping_items: array()
+        .of(
+          object().shape({
+            id: string().required(),
+            source_id: string().required(),
+            source_type: string().required(),
+            destination_id: string().required(),
+            destination_type: string().required(),
+            transformation_mapping_id: string().required()
+          })
+        )
+        .required()
+    })
+  )
+  .nullable();
+
+export const validateTransformationMappings = mappings => {
+  mappingsSchema
+    .validate(mappings, { abortEarly: false, strict: true })
+    .catch(err => {
+      logSchemaError(err);
+    });
+};
+
+const plansSchema = array()
+  .of(
+    object().shape({
+      href: string().required(),
+      id: string().required(),
+      name: string().required(),
+      description: string().nullable(),
+      options: object()
+        .shape({
+          config_info: object().shape({
+            transformation_mapping_id: string().required(),
+            vm_ids: array()
+              .of(string())
+              .required()
+          })
+        })
+        .required(),
+      created_at: string().required(),
+      miq_requests: array()
+        .of(
+          object().shape({
+            href: string().required(),
+            id: string().required(),
+            description: string().required(),
+            created_on: string().required(),
+            updated_on: string().nullable(),
+            fulfilled_on: string().nullable(),
+            request_state: string().required(),
+            status: string().required(),
+            options: object()
+              .shape({
+                src_id: string(),
+                delivered_on: string().nullable()
+              })
+              .required()
+          })
+        )
+        .nullable()
+    })
+  )
+  .nullable();
+
+export const validatePlans = plans => {
+  plansSchema
+    .validate(plans, { abortEarly: false, strict: true })
+    .catch(err => {
+      logSchemaError(err);
+    });
+};
+
+const requestsSchema = array()
+  .of(
+    object().shape({
+      href: string().required(),
+      id: string().required(),
+      description: string().nullable(),
+      approval_state: string().nullable(),
+      created_on: string().required(),
+      updated_on: string().nullable(),
+      fulfilled_on: string().nullable(),
+      request_state: string().nullable(),
+      status: string(),
+      options: object()
+        .shape({
+          delivered_on: string()
+        })
+        .required(),
+      miq_request_tasks: array()
+        .of(
+          object().shape({
+            href: string().required(),
+            id: string().required(),
+            description: string().required(),
+            state: string().required(),
+            options: object()
+              .shape({
+                src_id: string(),
+                delivered_on: string().nullable(),
+                transformation_host_name: string().nullable()
+              })
+              .required(),
+            created_on: string().required(),
+            updated_on: string().nullable(),
+            message: string().required(),
+            status: string().required()
+          })
+        )
+        .nullable()
+    })
+  )
+  .nullable();
+
+export const validateRequests = requests => {
+  requestsSchema
+    .validate(requests, { abortEarly: false, strict: true })
+    .catch(err => {
+      logSchemaError(err);
+    });
+};

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "core-js": "^2.5.7",
     "csv": "^2.0.0",
     "file-saver": "^1.3.8",
     "lodash.orderby": "^4.6.0",
@@ -83,7 +84,8 @@
     "table-resolver": "^3.2.0",
     "urijs": "^1.19.0",
     "utf8": "^3.0.0",
-    "uuid": "^3.2.1"
+    "uuid": "^3.2.1",
+    "yup": "^0.25.1"
   },
   "jest": {
     "setupFiles": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,6 +60,13 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@babel/runtime@^7.0.0-beta.47":
+  version "7.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.51.tgz#48b8ed18307034c6620f643514650ca2ccc0165a"
+  dependencies:
+    core-js "^2.5.7"
+    regenerator-runtime "^0.11.1"
+
 "@babel/template@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.44.tgz#f8832f4fdcee5d59bf515e595fc5106c529b394f"
@@ -1924,7 +1931,7 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
-core-js@^2.4.0, core-js@^2.5.0:
+core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.7:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
 
@@ -2798,6 +2805,10 @@ flat-cache@^1.2.1:
     del "^2.0.2"
     graceful-fs "^4.1.2"
     write "^0.2.1"
+
+fn-name@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
 
 follow-redirects@^1.3.0:
   version "1.5.0"
@@ -5066,6 +5077,10 @@ prop-types@^15.5.10, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.6.0,
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+property-expr@^1.2.0:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-1.3.2.tgz#2df60082c243e79118924ecb8f7ae7183b4fc43e"
+
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -5430,7 +5445,7 @@ regenerator-runtime@^0.10.5:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
-regenerator-runtime@^0.11.0:
+regenerator-runtime@^0.11.0, regenerator-runtime@^0.11.1:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
@@ -6106,6 +6121,10 @@ symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
+synchronous-promise@^1.0.18:
+  version "1.0.18"
+  resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-1.0.18.tgz#936e8763e6554088cdcf78dc64f7473b972fcefc"
+
 table-resolver@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/table-resolver/-/table-resolver-3.3.0.tgz#22e575d3c6aed15404ab71a0f2046c4ff55e556e"
@@ -6205,6 +6224,10 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
+
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
 
 tough-cookie@>=2.3.3, tough-cookie@^2.3.3:
   version "2.4.2"
@@ -6636,3 +6659,14 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+yup@^0.25.1:
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-0.25.1.tgz#09afe22af635fe11cf830a96ff4b906f8008f34e"
+  dependencies:
+    "@babel/runtime" "^7.0.0-beta.47"
+    fn-name "~2.0.1"
+    lodash "^4.17.10"
+    property-expr "^1.2.0"
+    synchronous-promise "^1.0.18"
+    toposort "^2.0.2"


### PR DESCRIPTION
Starts the UI schema validation for #424 

Adds validators for all of the Overview APIs. Would <3 some feedback on this. My current thinking is - these schemas will be screen/component specific (since we sometimes specify different attributes in the requests per page/component), so these schemas probably belong alongside the reducers. 

When a validation error is found, we'll get a notification in the UI like this:
<img width="467" alt="screen shot 2018-06-26 at 4 03 56 pm" src="https://user-images.githubusercontent.com/4237045/42062012-272dce0a-7afa-11e8-88cd-317580ed8ff4.png">

The goal of this is to quickly isolate UI/API integration issues in the QE test environments. QE should be able to quickly identify these and report them back to us (indicating a missed build integration or a missed API integration in the UI).

@AparnaKarve  - I was not able to dig through every field we currently use on the `Request` and `Plan` objects. This was an initial attempt. Will continue reviewing this but posting this for early 👀 