### PR TITLE
Check for valid `vms` before calculating the in active VMs length

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepReducer.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStepReducer.js
@@ -73,9 +73,9 @@ const _formatInvalidVms = vms => {
 };
 
 const _formatConflictVms = vms => {
-  const inactiveVM = vms && vms.filter(vm => vm.cluster === '' || vm.path === '');
-  const inactiveVMCount = inactiveVM.length;
-  const vmCount = inactiveVMCount > 0 ? vms.length - inactiveVMCount : vms.length;
+  const inactiveVMCount = (vms && vms.filter(vm => vm.cluster === '' || vm.path === '').length) || 0;
+  const allVMCount = (vms && vms.length) || 0;
+  const vmCount = inactiveVMCount > 0 ? allVMCount - inactiveVMCount : allVMCount;
   const uniqueIds = vms && [...new Set(vms.map(value => value.id))];
   return (
     vms &&


### PR DESCRIPTION
 Fix for `length of undefined` introduced in https://github.com/ManageIQ/miq_v2v_ui_plugin/pull/450

Wrapped up the `inactiveVMCount` logic in one line taking into account `vms`

https://bugzilla.redhat.com/show_bug.cgi?id=1596318