### PR TITLE
Ignore Mike's todolist json file...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ tmp/
 
 # IDE - VSCode
 .vscode/*
+
+# You guys should check out http://todolist.site/  (brew install todolist)
+.todos.json


### PR DESCRIPTION
I started using a command line todo list (check it out, `brew install todolist`) and it stores its data as a file in each repo (separate todo lists for each repo I work on).

By no means do you guys have to merge this. But if you do I won't have to keep seeing it red in my git status...

Alternatively, does anyone know a good solution for clone-specific .gitignore overrides, without committing the changes to .gitignore?