### PR TITLE
[WIP][#399] Pre/Post Playbook status in Overview page

### DIFF
--- a/app/javascript/react/screens/App/Overview/components/AggregateCards/ActiveTransformationPlans/ActiveTransformationPlans.js
+++ b/app/javascript/react/screens/App/Overview/components/AggregateCards/ActiveTransformationPlans/ActiveTransformationPlans.js
@@ -22,7 +22,15 @@ const ActiveTransformationPlans = ({ activePlans, allRequestsWithTasks, reloadCa
       const mostRecentRequest = requestsOfAssociatedPlan.length > 0 && getMostRecentRequest(requestsOfAssociatedPlan);
       return (
         mostRecentRequest &&
-        mostRecentRequest.miq_request_tasks.some(task => task.state === 'finished' && task.status === 'Error')
+        mostRecentRequest.miq_request_tasks.some(task => {
+          if (task.options && task.options.playbooks) {
+            const {
+              options: { playbooks }
+            } = task;
+            if (playbooks.pre.status === 'Failed' || playbooks.post.status === 'Failed') return true;
+          }
+          return task.state === 'finished' && task.status === 'Error';
+        })
       );
     }
     return [];

--- a/app/javascript/react/screens/App/Overview/components/AggregateCards/ActiveTransformationPlans/ActiveTransformationPlans.js
+++ b/app/javascript/react/screens/App/Overview/components/AggregateCards/ActiveTransformationPlans/ActiveTransformationPlans.js
@@ -24,10 +24,8 @@ const ActiveTransformationPlans = ({ activePlans, allRequestsWithTasks, reloadCa
         mostRecentRequest &&
         mostRecentRequest.miq_request_tasks.some(task => {
           if (task.options && task.options.playbooks) {
-            const {
-              options: { playbooks }
-            } = task;
-            if (playbooks.pre.status === 'Failed' || playbooks.post.status === 'Failed') return true;
+            const { pre, post } = task.options.playbooks;
+            if (pre.status === 'Failed' || post.status === 'Failed') return true;
           }
           return task.state === 'finished' && task.status === 'Error';
         })

--- a/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.js
@@ -49,6 +49,10 @@ const Migrations = ({
     setActiveFilter(eventKey);
   };
 
+  // TODO FIXME MJT: Remove this and every reference to it.
+  window.dangerousGlobalAccumulator = 0;
+  // This is to make it easy to do my lazy throwaway mock code.
+
   return (
     <React.Fragment>
       <Grid.Col xs={12}>

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressCard.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressCard.js
@@ -20,13 +20,11 @@ const MigrationsInProgressCard = ({ plan, allRequestsWithTasks, reloadCard, hand
   const mostRecentRequest = requestsOfAssociatedPlan.length > 0 && getMostRecentRequest(requestsOfAssociatedPlan);
 
 
-  // === TODO FIXME THIS IS MOCK MUTATION CODE TO BE REMOVED ===
+  // === TODO FIXME-- THE BELOW IS MOCK MUTATION CODE TO BE REMOVED ===
   // This code:
   // * sticks a fake active pre-playbook in the first migration on the screen
   // * sticks a fake active post-playbook in the third migration on the screen
-
   const a = window.dangerousGlobalAccumulator;
-
   const mockTasks = mostRecentRequest.miq_request_tasks.map((task, i) => ({
     ...task,
     options: {
@@ -45,14 +43,20 @@ const MigrationsInProgressCard = ({ plan, allRequestsWithTasks, reloadCard, hand
       }
     }
   }));
-
   window.dangerousGlobalAccumulator++;
   const mostRecentTasks = mockTasks;
-
-  // ^^^ TODO FIXME THIS IS MOCK MUTATION CODE TO BE REMOVED ^^^
+  // ^^^ TODO FIXME-- THE ABOVE IS MOCK MUTATION CODE TO BE REMOVED ^^^
   // We should remove the above code when the real API data is in place.
   
   // const mostRecentTasks = mostRecentRequest.miq_request_tasks;
+
+  const getActivePlaybook = task => {
+    if (!task || !task.options || !task.options.playbooks) return {};
+    const { options: { playbooks } } = task;
+    if (playbooks.pre.status === 'Active') return playbooks.pre;
+    if (playbooks.post.status === 'Active') return playbooks.post;
+    return {};
+  };
 
   const playbooksByTaskId = mostRecentTasks.reduce(
     (map, task) => ({
@@ -67,6 +71,7 @@ const MigrationsInProgressCard = ({ plan, allRequestsWithTasks, reloadCard, hand
     return playbooks.pre.status === 'Active' || playbooks.post.status === 'Active';
   });
   const isSomePlaybookActive = tasksWithActivePlaybooks.length > 0;
+  const activePlaybook = getActivePlaybook(tasksWithActivePlaybooks[0]);
 
   // if most recent request is still pending, show loading card
   if (reloadCard || !mostRecentRequest || mostRecentRequest.request_state === 'pending') {
@@ -93,12 +98,18 @@ const MigrationsInProgressCard = ({ plan, allRequestsWithTasks, reloadCard, hand
       <Grid.Col sm={12} md={6} lg={4}>
         <Card matchHeight>
           <Card.Heading>
-            <h3 className="card-pf-title">PLAN NAME!</h3>
+            <h3 className="card-pf-title">{plan.name}</h3>
           </Card.Heading>
           <Card.Body>
             <EmptyState>
               <Spinner loading size="lg" style={{ marginBottom: '15px' }} />
-              <EmptyState.Info>{__('Initiating migration. This might take a few minutes.')}</EmptyState.Info>
+              <EmptyState.Info>
+                {__('Running playbook service ')}
+                <strong>{activePlaybook.last_task}</strong>
+                {/* TODO/FIXME MJT:  ^^ I'm not sure if this is the string we want here. */}
+                <br />
+                {__('This might take a few minutes.')}
+              </EmptyState.Info>
             </EmptyState>
           </Card.Body>
         </Card>

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressCard.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsInProgressCard.js
@@ -55,30 +55,24 @@ const MigrationsInProgressCard = ({ plan, allRequestsWithTasks, reloadCard, hand
   const hasNoPlaybooks = task => !task || !task.options || !task.options.playbooks;
   const getActivePlaybook = task => {
     if (hasNoPlaybooks(task)) return {};
-    const {
-      options: { playbooks }
-    } = task;
-    if (playbooks.pre.status === 'Active') return playbooks.pre;
-    if (playbooks.post.status === 'Active') return playbooks.post;
+    const { pre, post } = task.options.playbooks;
+    if (pre.status === 'Active') return pre;
+    if (post.status === 'Active') return post;
     return {};
   };
 
   const tasksWithActivePlaybooks = mostRecentTasks.filter(task => {
     if (hasNoPlaybooks(task)) return false;
-    const {
-      options: { playbooks }
-    } = task;
-    return playbooks.pre.status === 'Active' || playbooks.post.status === 'Active';
+    const { pre, post } = task.options.playbooks;
+    return pre.status === 'Active' || post.status === 'Active';
   });
   const isSomePlaybookActive = tasksWithActivePlaybooks.length > 0;
   const activePlaybook = getActivePlaybook(tasksWithActivePlaybooks[0]);
 
   const isSomePlaybookFailed = mostRecentTasks.some(task => {
     if (hasNoPlaybooks(task)) return false;
-    const {
-      options: { playbooks }
-    } = task;
-    return playbooks.pre.status === 'Failed' || playbooks.post.status === 'Failed';
+    const { pre, post } = task.options.playbooks;
+    return pre.status === 'Failed' || post.status === 'Failed';
   });
 
   // UX business rule 1: reflect failed immediately if any single task has failed


### PR DESCRIPTION
fixes #399

My sincere thanks for bearing with me on my timeframe, here. Distractions upon distractions, I won't get into the details again.

Anyway, things are rolling again. Here's what I have so far here, I'm working on some of the error handling parts now. There is already one unknown in the code that makes me want a pair of eyes-- should we be using that `playbooks.pre.last_task` string for the "Running Playbook service: ____ " part of the card, like I've done? Or is there a better way to get the name of the playbook being run?

<img width="1306" alt="screen shot 2018-07-03 at 6 50 52 pm" src="https://user-images.githubusercontent.com/811963/42248455-99fe646a-7ef3-11e8-9e08-30a197b5ce94.png">


So far it just mocks the data as structured in Mike Ro's message on Slack earlier today, at the leaf node (so no Redux code ready to push yet). I have some Redux-y commits I rolled back that I'll add tomorrow. Sorry again for the delay @vconzola, but now that this PR is rolling, I'm thinking i'll be done tomorrow and ready to start a new issue Thursday.