### PR TITLE
[#471] pass empty pre and post playbooks to bypass playbook support for now

### DIFF
--- a/app/javascript/data/models/plans.js
+++ b/app/javascript/data/models/plans.js
@@ -11,9 +11,9 @@ export const plansSchema = array()
         .shape({
           config_info: object().shape({
             transformation_mapping_id: string().required(),
-            vm_ids: array()
-              .of(string())
-              .required()
+            actions: array()
+              .of(object().shape({ vm_id: string().required() }))
+              .nullable()
           })
         })
         .required(),

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -38,7 +38,7 @@ const MigrationsNotStartedList = ({ migrateClick, notStartedPlans, loading, redi
               additionalInfo={[
                 <ListView.InfoItem key={plan.id}>
                   <Icon type="pf" name="virtual-machine" />
-                  <strong>{plan.options.config_info.vm_ids.length}</strong> {__('VMs')}
+                  <strong>{plan.options.config_info.actions.length}</strong> {__('VMs')}
                 </ListView.InfoItem>
               ]}
               key={plan.id}

--- a/app/javascript/react/screens/App/Overview/overview.transformationPlans.fixtures.js
+++ b/app/javascript/react/screens/App/Overview/overview.transformationPlans.fixtures.js
@@ -14,7 +14,7 @@ export const transformationPlans = Immutable({
       options: {
         config_info: {
           transformation_mapping_id: '1',
-          vm_ids: ['1', '3']
+          actions: [{ vm_id: '1' }, { vm_id: '3' }]
         }
       },
       created_at: '2018-05-01T12:15:00Z',
@@ -29,7 +29,7 @@ export const transformationPlans = Immutable({
       options: {
         config_info: {
           transformation_mapping_id: '1',
-          vm_ids: ['1', '3']
+          actions: [{ vm_id: '1' }, { vm_id: '3' }]
         }
       },
       miq_requests: [
@@ -78,7 +78,7 @@ export const transformationPlans = Immutable({
       options: {
         config_info: {
           transformation_mapping_id: '1',
-          vm_ids: ['1', '3']
+          actions: [{ vm_id: '1' }, { vm_id: '3' }]
         }
       },
       created_at: '2018-05-01T12:13:50Z',
@@ -163,7 +163,7 @@ export const transformationPlans = Immutable({
       options: {
         config_info: {
           transformation_mapping_id: '1',
-          vm_ids: ['1', '3']
+          actions: [{ vm_id: '1' }, { vm_id: '3' }]
         }
       },
       created_at: '2018-05-01T12:13:50',
@@ -214,7 +214,7 @@ export const transformationPlans = Immutable({
       options: {
         config_info: {
           transformation_mapping_id: '1',
-          vm_ids: ['1', '3']
+          actions: [{ vm_id: '1' }, { vm_id: '3' }]
         }
       },
       created_at: '2018-05-01T12:13:50Z',
@@ -265,7 +265,7 @@ export const transformationPlans = Immutable({
       options: {
         config_info: {
           transformation_mapping_id: '1',
-          vm_ids: ['1', '3']
+          actions: [{ vm_id: '1' }, { vm_id: '3' }]
         }
       },
       created_at: '2018-05-01T12:13:50Z',

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardResultsStep/planWizardResultsStep.fixtures.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardResultsStep/planWizardResultsStep.fixtures.js
@@ -13,7 +13,7 @@ export const migrationPlansResult = Immutable({
       options: {
         config_info: {
           transformation_mapping_id: '10000000000001',
-          vm_ids: ['1', '9', '23']
+          actions: [{ vm_id: '1' }, { vm_id: '9' }, { vm_id: '23' }]
         }
       },
       created_at: '2018-02-07T16:02:39Z',

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/helpers.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/helpers.js
@@ -3,14 +3,16 @@ export const createMigrationPlans = (planWizardGeneralStep, planWizardVMStep) =>
   const planDescription = planWizardGeneralStep.values.description;
   const infrastructureMapping = planWizardGeneralStep.values.infrastructure_mapping;
   const vms = planWizardVMStep.values.selectedVms;
-
+  const actions = vms.map(vmId => ({
+    vm_id: vmId
+  }));
   return {
     name: planName,
     description: planDescription,
     prov_type: 'generic_transformation_plan',
     config_info: {
       transformation_mapping_id: infrastructureMapping,
-      vm_ids: vms
+      actions
     }
   };
 };

--- a/app/javascript/react/screens/App/Plan/Plan.js
+++ b/app/javascript/react/screens/App/Plan/Plan.js
@@ -52,9 +52,14 @@ class Plan extends React.Component {
       const {
         miq_requests,
         options: {
-          config_info: { vm_ids }
+          config_info: { actions }
         }
       } = plan;
+
+      let vm_ids = [];
+      if (actions && actions.length) {
+        vm_ids = actions.map(a => a.vm_id);
+      }
 
       if (miq_requests.length > 0) {
         const mostRecentRequest = getMostRecentRequest(miq_requests);


### PR DESCRIPTION
fixes #471 

Temporarily pass empty pre/post playbook services to allow UI to continue creating plans in the upstream code.

W.I.P. ⚠️ 