### PR TITLE
Migration Status string constants for i18n

### DIFF
--- a/app/javascript/react/screens/App/Plan/PlanConstants.js
+++ b/app/javascript/react/screens/App/Plan/PlanConstants.js
@@ -7,29 +7,47 @@ export const FETCH_V2V_MIGRATION_TASK_LOG = 'FETCH_V2V_MIGRATION_TASK_LOG';
 export const DOWNLOAD_LOG_CLICKED = 'DOWNLOAD_LOG_CLICKED';
 export const DOWNLOAD_LOG_COMPLETED = 'DOWNLOAD_LOG_COMPLETED';
 
-export const V2V_MIGRATION_STATUS_MESSAGES = {
-  'Acquire Transformation Host': __('Acquire Transformation Host'),
-  'Assess Migration': __('Assess Migration'),
-  'Automation Starting': __('Automation Starting'),
-  'Collapse Snapshots': __('Collapse Snapshots'),
-  'Convert disks': __('Convert disks'),
-  'Mark source as migrated': __('Mark source as migrated'),
-  Migrating: __('Migrating'),
-  'Migration complete': __('Migration complete'),
-  'Power off': __('Power off'),
-  'Power-on VM': __('Power-on VM'),
-  'Pre-migration': __('Pre-migration'),
-  'Refresh inventory': __('Refresh inventory'),
-  'Restore VM Attributes': __('Restore VM Attributes'),
-  'Transform VM': __('Migrate VM'),
-  'Update description of VM': __('Update description of VM'),
-  Validating: __('Validating'),
-  'VM Transformations completed': __('VM Migrations completed'),
-  'Virtual machine migrated': __('Virtual machine migrated'),
-  'VM Transformations failed': __('VM Migrations failed')
+export const STATUS_MESSAGE_KEYS = {
+  ACQUIRE_TRANSFORMATION_HOST: 'Acquire Transformation Host',
+  ASSESS_MIGRATION: 'Assess Migration',
+  AUTOMATION_STARTING: 'Automation Starting',
+  COLLAPSE_SNAPSHOTS: 'Collapse Snapshots',
+  CONVERT_DISKS: 'Convert disks',
+  SOURCE_MIGRATED: 'Mark source as migrated',
+  MIGRATING: 'Migrating',
+  MIGRATION_COMPLETE: 'Migration complete',
+  POWER_OFF: 'Power off',
+  POWER_ON: 'Power-on VM',
+  PRE_MIGRATION: 'Pre-migration',
+  REFRESH_INVENTORY: 'Refresh inventory',
+  RESTORE_VM_ATTRIBUTES: 'Restore VM Attributes',
+  MIGRATE_VM: 'Transform VM',
+  UPDATE_DESCRIPTION: 'Update description of VM',
+  VALIDATING: 'Validating',
+  VM_MIGRATIONS_COMPLETED: 'VM Transformations completed',
+  VM_MIGRATED: 'Virtual machine migrated',
+  VM_MIGRATIONS_FAILED: 'VM Transformations failed'
 };
 
-export const ORIGINAL_V2V_MIGRATION_STATUS_MESSAGES = {
-  VM_Transformations_Completed: 'VM Transformations completed',
-  VM_Transformations_Failed: 'VM Transformations failed'
-};
+const STATUS_MESSAGES = {};
+STATUS_MESSAGES[STATUS_MESSAGE_KEYS.ACQUIRE_TRANSFORMATION_HOST] = __('Acquire Transformation Host');
+STATUS_MESSAGES[STATUS_MESSAGE_KEYS.ASSESS_MIGRATION] = __('Assess Migration');
+STATUS_MESSAGES[STATUS_MESSAGE_KEYS.AUTOMATION_STARTING] = __('Automation Starting');
+STATUS_MESSAGES[STATUS_MESSAGE_KEYS.COLLAPSE_SNAPSHOTS] = __('Collapse Snapshots');
+STATUS_MESSAGES[STATUS_MESSAGE_KEYS.CONVERT_DISKS] = __('Convert disks');
+STATUS_MESSAGES[STATUS_MESSAGE_KEYS.SOURCE_MIGRATED] = __('Mark source as migrated');
+STATUS_MESSAGES[STATUS_MESSAGE_KEYS.MIGRATING] = __('Migrating');
+STATUS_MESSAGES[STATUS_MESSAGE_KEYS.MIGRATION_COMPLETE] = __('Migration complete');
+STATUS_MESSAGES[STATUS_MESSAGE_KEYS.POWER_OFF] = __('Power off');
+STATUS_MESSAGES[STATUS_MESSAGE_KEYS.POWER_ON] = __('Power-on VM');
+STATUS_MESSAGES[STATUS_MESSAGE_KEYS.PRE_MIGRATION] = __('Pre-migration');
+STATUS_MESSAGES[STATUS_MESSAGE_KEYS.REFRESH_INVENTORY] = __('Refresh inventory');
+STATUS_MESSAGES[STATUS_MESSAGE_KEYS.RESTORE_VM_ATTRIBUTES] = __('Restore VM Attributes');
+STATUS_MESSAGES[STATUS_MESSAGE_KEYS.MIGRATE_VM] = __('Migrate VM');
+STATUS_MESSAGES[STATUS_MESSAGE_KEYS.UPDATE_DESCRIPTION] = __('Update description of VM');
+STATUS_MESSAGES[STATUS_MESSAGE_KEYS.VALIDATING] = __('Validating');
+STATUS_MESSAGES[STATUS_MESSAGE_KEYS.VM_MIGRATIONS_COMPLETED] = __('VM migrations completed');
+STATUS_MESSAGES[STATUS_MESSAGE_KEYS.VM_MIGRATED] = __('Virtual machine migrated');
+STATUS_MESSAGES[STATUS_MESSAGE_KEYS.VM_MIGRATIONS_FAILED] = __('VM migrations failed');
+
+export { STATUS_MESSAGES as V2V_MIGRATION_STATUS_MESSAGES };

--- a/app/javascript/react/screens/App/Plan/PlanConstants.js
+++ b/app/javascript/react/screens/App/Plan/PlanConstants.js
@@ -6,3 +6,25 @@ export const RESET_PLAN_STATE = 'RESET_PLAN_STATE';
 export const FETCH_V2V_MIGRATION_TASK_LOG = 'FETCH_V2V_MIGRATION_TASK_LOG';
 export const DOWNLOAD_LOG_CLICKED = 'DOWNLOAD_LOG_CLICKED';
 export const DOWNLOAD_LOG_COMPLETED = 'DOWNLOAD_LOG_COMPLETED';
+
+export const V2V_MIGRATION_STATUS_MESSAGES = {
+  'Acquire Transformation Host': __('Acquire Transformation Host'),
+  'Assess Migration': __('Assess Migration'),
+  'Automation Starting': __('Automation Starting'),
+  'Collapse Snapshots': __('Collapse Snapshots'),
+  'Convert disks': __('Convert disks'),
+  'Mark source as migrated': __('Mark source as migrated'),
+  Migrating: __('Migrating'),
+  'Migration complete': __('Migration complete'),
+  'Power off': __('Power off'),
+  'Power-on VM': __('Power-on VM'),
+  'Pre-migration': __('Pre-migration'),
+  'Refresh inventory': __('Refresh inventory'),
+  'Restore VM Attributes': __('Restore VM Attributes'),
+  'Transform VM': __('Transform VM'),
+  'Update description of VM': __('Update description of VM'),
+  Validating: __('Validating'),
+  'VM Transformations completed': __('VM Transformations completed'),
+  'Virtual machine migrated': __('Virtual machine migrated'),
+  'VM Transformations failed': __('VM Transformations failed')
+};

--- a/app/javascript/react/screens/App/Plan/PlanConstants.js
+++ b/app/javascript/react/screens/App/Plan/PlanConstants.js
@@ -28,3 +28,8 @@ export const V2V_MIGRATION_STATUS_MESSAGES = {
   'Virtual machine migrated': __('Virtual machine migrated'),
   'VM Transformations failed': __('VM Migrations failed')
 };
+
+export const ORIGINAL_V2V_MIGRATION_STATUS_MESSAGES = {
+  VM_Transformations_Completed: 'VM Transformations completed',
+  VM_Transformations_Failed: 'VM Transformations failed'
+};

--- a/app/javascript/react/screens/App/Plan/PlanConstants.js
+++ b/app/javascript/react/screens/App/Plan/PlanConstants.js
@@ -21,10 +21,10 @@ export const V2V_MIGRATION_STATUS_MESSAGES = {
   'Pre-migration': __('Pre-migration'),
   'Refresh inventory': __('Refresh inventory'),
   'Restore VM Attributes': __('Restore VM Attributes'),
-  'Transform VM': __('Transform VM'),
+  'Transform VM': __('Migrate VM'),
   'Update description of VM': __('Update description of VM'),
   Validating: __('Validating'),
-  'VM Transformations completed': __('VM Transformations completed'),
+  'VM Transformations completed': __('VM Migrations completed'),
   'Virtual machine migrated': __('Virtual machine migrated'),
-  'VM Transformations failed': __('VM Transformations failed')
+  'VM Transformations failed': __('VM Migrations failed')
 };

--- a/app/javascript/react/screens/App/Plan/PlanReducer.js
+++ b/app/javascript/react/screens/App/Plan/PlanReducer.js
@@ -13,7 +13,7 @@ import {
   DOWNLOAD_LOG_CLICKED,
   DOWNLOAD_LOG_COMPLETED,
   V2V_MIGRATION_STATUS_MESSAGES,
-  ORIGINAL_V2V_MIGRATION_STATUS_MESSAGES
+  STATUS_MESSAGE_KEYS
 } from './PlanConstants';
 
 export const initialState = Immutable({
@@ -50,8 +50,8 @@ const processVMTasks = vmTasks => {
       delivered_on: new Date(task.options.delivered_on),
       updated_on: new Date(task.updated_on),
       completed:
-        task.message === ORIGINAL_V2V_MIGRATION_STATUS_MESSAGES.VM_Transformations_Completed ||
-        task.message === ORIGINAL_V2V_MIGRATION_STATUS_MESSAGES.VM_Transformations_Failed,
+        task.message === STATUS_MESSAGE_KEYS.VM_MIGRATIONS_COMPLETED ||
+        task.message === STATUS_MESSAGE_KEYS.VM_MIGRATIONS_FAILED,
       state: task.state,
       status: task.status,
       options: {}

--- a/app/javascript/react/screens/App/Plan/PlanReducer.js
+++ b/app/javascript/react/screens/App/Plan/PlanReducer.js
@@ -2,6 +2,7 @@ import Immutable from 'seamless-immutable';
 import numeral from 'numeral';
 import commonUtilitiesHelper from '../common/commonUtilitiesHelper';
 import getMostRecentVMTasksFromRequests from '../Overview/components/Migrations/helpers/getMostRecentVMTasksFromRequests';
+import { IsoElapsedTime } from '../../../../components/dates/IsoElapsedTime';
 
 import {
   FETCH_V2V_PLAN,
@@ -81,6 +82,8 @@ const processVMTasks = vmTasks => {
     const lastUpdateDateTime = taskDetails.updated_on;
     taskDetails.startDateTime = startDateTime;
     taskDetails.lastUpdateDateTime = lastUpdateDateTime;
+
+    taskDetails.elapsedTime = IsoElapsedTime(new Date(startDateTime), new Date(lastUpdateDateTime));
 
     if (taskDetails.completed) {
       taskDetails.completedSuccessfully =

--- a/app/javascript/react/screens/App/Plan/PlanReducer.js
+++ b/app/javascript/react/screens/App/Plan/PlanReducer.js
@@ -10,7 +10,8 @@ import {
   RESET_PLAN_STATE,
   FETCH_V2V_MIGRATION_TASK_LOG,
   DOWNLOAD_LOG_CLICKED,
-  DOWNLOAD_LOG_COMPLETED
+  DOWNLOAD_LOG_COMPLETED,
+  V2V_MIGRATION_STATUS_MESSAGES
 } from './PlanConstants';
 
 export const initialState = Immutable({
@@ -42,11 +43,13 @@ const processVMTasks = vmTasks => {
   vmTasks.forEach(task => {
     const taskDetails = {
       id: task.id,
-      message: task.message,
+      message: V2V_MIGRATION_STATUS_MESSAGES[task.message],
       transformation_host_name: task.options && task.options.transformation_host_name,
       delivered_on: new Date(task.options.delivered_on),
       updated_on: new Date(task.updated_on),
-      completed: task.message === 'VM Transformations completed' || task.message === 'VM Transformations failed',
+      completed:
+        task.message === V2V_MIGRATION_STATUS_MESSAGES['VM Transformations completed'] ||
+        task.message === V2V_MIGRATION_STATUS_MESSAGES['VM Transformations failed'],
       state: task.state,
       status: task.status,
       options: {}

--- a/app/javascript/react/screens/App/Plan/PlanReducer.js
+++ b/app/javascript/react/screens/App/Plan/PlanReducer.js
@@ -11,7 +11,8 @@ import {
   FETCH_V2V_MIGRATION_TASK_LOG,
   DOWNLOAD_LOG_CLICKED,
   DOWNLOAD_LOG_COMPLETED,
-  V2V_MIGRATION_STATUS_MESSAGES
+  V2V_MIGRATION_STATUS_MESSAGES,
+  ORIGINAL_V2V_MIGRATION_STATUS_MESSAGES
 } from './PlanConstants';
 
 export const initialState = Immutable({
@@ -48,8 +49,8 @@ const processVMTasks = vmTasks => {
       delivered_on: new Date(task.options.delivered_on),
       updated_on: new Date(task.updated_on),
       completed:
-        task.message === V2V_MIGRATION_STATUS_MESSAGES['VM Transformations completed'] ||
-        task.message === V2V_MIGRATION_STATUS_MESSAGES['VM Transformations failed'],
+        task.message === ORIGINAL_V2V_MIGRATION_STATUS_MESSAGES.VM_Transformations_Completed ||
+        task.message === ORIGINAL_V2V_MIGRATION_STATUS_MESSAGES.VM_Transformations_Failed,
       state: task.state,
       status: task.status,
       options: {}

--- a/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
@@ -387,7 +387,7 @@ class PlanRequestDetailList extends React.Component {
                       }}
                     >
                       <div>
-                        <span style={{ textTransform: 'capitalize' }}>{task.message}</span>
+                        <span>{task.message}</span>
                         &nbsp;
                         {/* Todo: revisit FieldLevelHelp props in patternfly-react to support this */}
                         <OverlayTrigger rootClose trigger="click" placement="left" overlay={popoverContent}>

--- a/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
@@ -27,6 +27,7 @@ import {
   ACTIVE_PLAN_SORT_FIELDS,
   FINISHED_PLAN_SORT_FIELDS
 } from './PlanRequestDetailListConstants';
+import { V2V_MIGRATION_STATUS_MESSAGES } from '../../PlanConstants';
 import TickingIsoElapsedTime from '../../../../../../components/dates/TickingIsoElapsedTime';
 
 class PlanRequestDetailList extends React.Component {
@@ -338,7 +339,11 @@ class PlanRequestDetailList extends React.Component {
               const label = sprintf(__('%s of %s Migrated'), task.diskSpaceCompletedGb, task.totalDiskSpaceGb);
 
               const popoverContent = (
-                <Popover id={`popover${task.id}${n}`} title={task.message} className="task-info-popover">
+                <Popover
+                  id={`popover${task.id}${n}`}
+                  title={V2V_MIGRATION_STATUS_MESSAGES[task.message]}
+                  className="task-info-popover"
+                >
                   <div>
                     <div>
                       <b>{__('Started')}: </b>
@@ -346,7 +351,8 @@ class PlanRequestDetailList extends React.Component {
                     </div>
                     <div>
                       <b>{__('Description')}: </b>
-                      {task.options.progress && task.options.progress.current_description}
+                      {task.options.progress &&
+                        V2V_MIGRATION_STATUS_MESSAGES[task.options.progress.current_description]}
                     </div>
                     <div>
                       <b>{__('Conversion Host')}: </b>

--- a/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
@@ -346,7 +346,7 @@ class PlanRequestDetailList extends React.Component {
                 >
                   <div>
                     <div>
-                      <b>{__('Started')}: </b>
+                      <b>{__('Elapsed Time')}: </b>
                       {formatDateTime(task.startDateTime)}
                     </div>
                     <div>

--- a/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailListConstants.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailListConstants.js
@@ -1,3 +1,5 @@
+import { V2V_MIGRATION_STATUS_MESSAGES, STATUS_MESSAGE_KEYS } from '../../PlanConstants';
+
 export const FINISHED_PLAN_FILTER_TYPES = [
   {
     id: 'vmName',
@@ -27,17 +29,19 @@ export const ACTIVE_PLAN_FILTER_TYPES = [
     placeholder: __('Filter by Status'),
     filterType: 'select',
     filterValues: [
-      { title: __('Pending'), id: 'Pending' },
-      { title: __('Validating'), id: 'Validating' },
-      { title: __('Pre-migration'), id: 'Pre-migration' },
-      { title: __('Migrating'), id: 'Migrating' },
+      { title: V2V_MIGRATION_STATUS_MESSAGES[STATUS_MESSAGE_KEYS.VALIDATING], id: STATUS_MESSAGE_KEYS.VALIDATING },
       {
-        title: __('VM Transformations completed'),
-        id: 'VM Transformations completed'
+        title: V2V_MIGRATION_STATUS_MESSAGES[STATUS_MESSAGE_KEYS.PRE_MIGRATION],
+        id: STATUS_MESSAGE_KEYS.PRE_MIGRATION
+      },
+      { title: V2V_MIGRATION_STATUS_MESSAGES[STATUS_MESSAGE_KEYS.MIGRATING], id: STATUS_MESSAGE_KEYS.MIGRATING },
+      {
+        title: V2V_MIGRATION_STATUS_MESSAGES[STATUS_MESSAGE_KEYS.VM_MIGRATIONS_COMPLETED],
+        id: STATUS_MESSAGE_KEYS.VM_MIGRATIONS_COMPLETED
       },
       {
-        title: __('VM Transformations failed'),
-        id: 'VM Transformations failed'
+        title: V2V_MIGRATION_STATUS_MESSAGES[STATUS_MESSAGE_KEYS.VM_MIGRATIONS_FAILED],
+        id: STATUS_MESSAGE_KEYS.VM_MIGRATIONS_FAILED
       }
     ]
   }

--- a/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailListConstants.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailListConstants.js
@@ -44,7 +44,7 @@ export const ACTIVE_PLAN_FILTER_TYPES = [
 ];
 
 export const FINISHED_PLAN_SORT_FIELDS = [
-  { id: 'elapsedTime', title: __('Started'), isNumeric: false },
+  { id: 'elapsedTime', title: __('Elapsed Time'), isNumeric: false },
   {
     id: 'vmName',
     title: __('VM Name'),
@@ -54,7 +54,7 @@ export const FINISHED_PLAN_SORT_FIELDS = [
 ];
 
 export const ACTIVE_PLAN_SORT_FIELDS = [
-  { id: 'elapsedTime', title: __('Started'), isNumeric: false },
+  { id: 'elapsedTime', title: __('Elapsed Time'), isNumeric: false },
   {
     id: 'vmName',
     title: __('VM Name'),


### PR DESCRIPTION
Fixes  #255

None of the Migration status strings from the backend were being addressed for i18n/gettext.

Thanks @AllenBW for noticing this in #468

I have included all the strings from -
https://github.com/ManageIQ/manageiq-content/blob/d0cbbf2eed56b75cb737c650ec72b1504c8a31b8/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/transformation.yaml

and 

https://github.com/ManageIQ/manageiq-content/blob/f0e6ca25f23ed4a88a87cdecc6f1066aa30898ec/content/automate/ManageIQ/Transformation/StateMachines/VMTransformation.class/vmwarews2rhevm_vddk.yaml

that show up in the Plan detail page.

