### PR TITLE
Display log location in the VM Migration Task Popover

### DIFF
--- a/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
@@ -352,14 +352,16 @@ class PlanRequestDetailList extends React.Component {
                       <b>{__('Conversion Host')}: </b>
                       {task.transformation_host_name}
                     </div>
-                    {task.taskCompleted && (
-                      <div>
-                        <br />
-                        <strong>Log:</strong>
-                        <br />
-                        {task.options.virtv2v_wrapper && task.options.virtv2v_wrapper.v2v_log}
-                      </div>
-                    )}
+                    {task.completed &&
+                      task.options.virtv2v_wrapper &&
+                      task.options.virtv2v_wrapper.v2v_log.length > 0 && (
+                        <div>
+                          <br />
+                          <strong>{__('Log:')}</strong>
+                          <br />
+                          {task.options.virtv2v_wrapper.v2v_log}
+                        </div>
+                      )}
                   </div>
                 </Popover>
               );


### PR DESCRIPTION
While the code existed all along to display the location of the log in the Migration task popover, it was never displaying (because of using the wrong flag `taskCompleted`)

Before -
<img width="1176" alt="screen shot 2018-07-10 at 10 20 39 am" src="https://user-images.githubusercontent.com/1538216/42527070-7e930f26-842c-11e8-8d96-59ceb63769f6.png">

After - 
<img width="1177" alt="screen shot 2018-07-10 at 10 23 46 am" src="https://user-images.githubusercontent.com/1538216/42527081-86b19704-842c-11e8-9bb3-f528f896fe1b.png">

