### PR TITLE
Remove Settings.product.transformation - no longer conditional on a product feature

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,9 @@
 # ManageIQ::V2V::Engine.routes.draw do
-if ::Settings.product.transformation == true
-  Rails.application.routes.draw do
-    match '/migration' => 'migration#index', :via => [:get]
-    match 'migration/*page' => 'migration#index', :via => [:get]
+Rails.application.routes.draw do
+  match '/migration' => 'migration#index', :via => [:get]
+  match 'migration/*page' => 'migration#index', :via => [:get]
 
-    get "migration_log/download_migration_log(/:id)",
-      :action     => 'download_migration_log',
-      :controller => 'migration_log'
-  end
+  get "migration_log/download_migration_log(/:id)",
+    :action     => 'download_migration_log',
+    :controller => 'migration_log'
 end

--- a/lib/manageiq/v2v/engine.rb
+++ b/lib/manageiq/v2v/engine.rb
@@ -12,7 +12,7 @@ module ManageIQ::V2V
 
     initializer 'plugin' do
       Menu::CustomLoader.register(
-        ::Settings.product.transformation == true ? Menu::Item.new('migration', N_('Migration'), 'migration', {:feature => 'migration', :any => true}, '/migration', :default, :compute) : nil
+        Menu::Item.new('migration', N_('Migration'), 'migration', {:feature => 'migration', :any => true}, '/migration', :default, :compute)
       )
     end
   end


### PR DESCRIPTION
We're using rbac now, from #417

Fixes #432

@Fryguy , @priley86 I have no idea about the gaprindashvili status of this? Should the new builds have it enabled too, or is the product feature removal hammer only?