### PR TITLE
Adds vm# sorting and clock icon to plan not started list

### DIFF
--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -183,6 +183,7 @@ class MigrationsNotStartedList extends React.Component {
                           </ListView.InfoItem>,
                           migrationScheduled && (
                             <ListView.InfoItem key={plan.id + 1} style={{ textAlign: 'left' }}>
+                              <Icon type="fa" name="clock-o" />
                               {__(`Migration scheduled`)}
                               <br />
                               {formatDateTime(migrationScheduled)}


### PR DESCRIPTION
https://github.com/ManageIQ/miq_v2v_ui_plugin/issues/496 has mocks with clock icon for scheduling, so adding that and the `Number of VMs` sorting option

related to #427, should use the same bz

<img width="1920" alt="screen shot 2018-07-18 at 9 17 00 am" src="https://user-images.githubusercontent.com/6640236/42884081-62a0771e-8a6b-11e8-810e-49ed6dcea951.png">
