### PR TITLE
Adds infra mapping plan name to transformation plans

### DIFF
--- a/app/javascript/react/screens/App/Overview/OverviewReducer.js
+++ b/app/javascript/react/screens/App/Overview/OverviewReducer.js
@@ -43,6 +43,8 @@ import {
   V2V_SCHEDULE_MIGRATION
 } from './OverviewConstants';
 
+import getMostRecentRequest from '../common/getMostRecentRequest';
+
 export const initialState = Immutable({
   mappingWizardVisible: false,
   hideMappingWizard: true,
@@ -180,13 +182,29 @@ export default (state = initialState, action) => {
         .set('isFetchingTransformationMappings', false);
     case `${FETCH_V2V_TRANSFORMATION_PLANS}_PENDING`:
       return state.set('isFetchingTransformationPlans', true);
-    case `${FETCH_V2V_TRANSFORMATION_PLANS}_FULFILLED`:
+    case `${FETCH_V2V_TRANSFORMATION_PLANS}_FULFILLED`: {
       validateOverviewPlans(action.payload.data.resources);
+      const planTransmutation = (plans = [], mappings = []) =>
+        plans.map(plan => {
+          const infraMappingName = mappings.find(
+            mapping => mapping.id === plan.options.config_info.transformation_mapping_id
+          );
+          const status = getMostRecentRequest(plan.miq_requests);
+          return {
+            ...plan,
+            infraMappingName: infraMappingName ? infraMappingName.name : null,
+            status: status ? status.status : null,
+            configVmLength: plan.options.config_info.actions.length,
+            scheduleTime: plan.schedules ? new Date(plan.schedules[0].run_at.start_time).getTime() : null
+          };
+        });
+
       return state
-        .set('transformationPlans', action.payload.data.resources)
+        .set('transformationPlans', planTransmutation(action.payload.data.resources, state.transformationMappings))
         .set('isFetchingTransformationPlans', false)
         .set('isRejectedTransformationPlans', false)
         .set('errorTransformationPlans', null);
+    }
     case `${FETCH_V2V_TRANSFORMATION_PLANS}_REJECTED`:
       return state
         .set('errorTransformationPlans', action.payload)

--- a/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.js
@@ -45,7 +45,6 @@ const Migrations = ({
   ];
 
   const plansExist = transformationPlans.length > 0 || archivedTransformationPlans.length > 0;
-
   const onSelect = eventKey => {
     if (eventKey === MIGRATIONS_FILTERS.archived) {
       fetchTransformationPlansAction({

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -58,7 +58,6 @@ class MigrationsCompletedList extends React.Component {
       archived
     } = this.props;
     const sortedMigrations = this.sortedMigrations();
-    finishedTransformationPlans.map(plan => (plan.status = getMostRecentRequest(plan.miq_requests).status));
 
     return (
       <Grid.Col xs={12}>
@@ -174,6 +173,7 @@ class MigrationsCompletedList extends React.Component {
 
                   return (
                     <ListView.Item
+                      stacked
                       className="plans-complete-list__list-item"
                       onClick={() => {
                         redirectTo(`/migration/plan/${plan.id}`);
@@ -210,6 +210,9 @@ class MigrationsCompletedList extends React.Component {
                           <ListView.Icon type="pf" size="lg" name="screen" />&nbsp;<strong>{succeedCount}</strong>{' '}
                           {__('of')} &nbsp;<strong>{Object.keys(tasks).length} </strong>
                           {__('VMs successfully migrated.')}
+                        </ListView.InfoItem>,
+                        <ListView.InfoItem key={`${plan.id}-infraMappingName`}>
+                          {plan.infraMappingName}
                         </ListView.InfoItem>,
                         <ListView.InfoItem key={`${plan.id}-elapsed`}>
                           <ListView.Icon type="fa" size="lg" name="clock-o" />

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsConstants.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsConstants.js
@@ -1,8 +1,13 @@
 export const MIGRATIONS_NOT_STARTED_SORT_FIELDS = [
   { id: 'name', title: __('Name'), isNumeric: false },
   {
-    id: 'configVmLength',
+    id: 'infraMappingName',
     title: __('Infrastructure Mapping'),
+    isNumeric: false
+  },
+  {
+    id: 'configVmLength',
+    title: __('Number of VMs'),
     isNumeric: true
   },
   { id: 'scheduleTime', title: __('Scheduled Time'), isNumeric: true }

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -20,16 +20,7 @@ class MigrationsNotStartedList extends React.Component {
     const { currentSortType, isSortNumeric, isSortAscending } = this.state;
     const { notStartedPlans } = this.props;
 
-    return sortFilter(
-      currentSortType,
-      isSortNumeric,
-      isSortAscending,
-      notStartedPlans.map(plan => ({
-        ...plan,
-        configVmLength: plan.options.config_info.actions.length,
-        scheduleTime: plan.schedules ? new Date(plan.schedules[0].run_at.start_time).getTime() : 0
-      }))
-    );
+    return sortFilter(currentSortType, isSortNumeric, isSortAscending, notStartedPlans);
   };
 
   toggleCurrentSortDirection = () => {
@@ -132,6 +123,7 @@ class MigrationsNotStartedList extends React.Component {
 
                     return (
                       <ListView.Item
+                        stacked
                         className="plans-not-started-list__list-item"
                         onClick={() => {
                           redirectTo(`/migration/plan/${plan.id}`);
@@ -182,6 +174,9 @@ class MigrationsNotStartedList extends React.Component {
                           <ListView.InfoItem key={plan.id}>
                             <Icon type="pf" name="virtual-machine" />
                             <strong>{plan.options.config_info.actions.length}</strong> {__('VMs')}
+                          </ListView.InfoItem>,
+                          <ListView.InfoItem key={`${plan.id}-infraMappingName`}>
+                            {plan.infraMappingName}
                           </ListView.InfoItem>,
                           migrationScheduled && (
                             <ListView.InfoItem key={plan.id + 1} style={{ textAlign: 'left' }}>

--- a/app/javascript/react/screens/App/Overview/overview.transformationPlans.fixtures.js
+++ b/app/javascript/react/screens/App/Overview/overview.transformationPlans.fixtures.js
@@ -19,7 +19,11 @@ export const transformationPlans = Immutable({
       },
       created_on: '2018-05-01T12:15:00Z',
       id: '10',
-      miq_requests: []
+      miq_requests: [],
+      configVmLength: 2,
+      infraMappingName: null,
+      scheduleTime: null,
+      status: null
     },
     // PLAN B-0 APPROVED
     // |-- Request 1: pending
@@ -67,7 +71,11 @@ export const transformationPlans = Immutable({
           service_order_id: '92',
           process: true
         }
-      ]
+      ],
+      configVmLength: 2,
+      infraMappingName: null,
+      scheduleTime: null,
+      status: 'Ok'
     },
     // PLAN C-0 APPROVED
     // |-- Request 1: failed
@@ -153,7 +161,11 @@ export const transformationPlans = Immutable({
           service_order_id: '91',
           process: true
         }
-      ]
+      ],
+      configVmLength: 2,
+      infraMappingName: null,
+      scheduleTime: null,
+      status: 'Ok'
     },
     // PLAN D-0 FAILED
     // |-- Request 1: failed
@@ -204,7 +216,11 @@ export const transformationPlans = Immutable({
           service_order_id: '91',
           process: true
         }
-      ]
+      ],
+      configVmLength: 2,
+      infraMappingName: null,
+      scheduleTime: null,
+      status: 'Error'
     },
     // PLAN E-0 COMPLETE
     // |-- Request 1: complete
@@ -255,7 +271,11 @@ export const transformationPlans = Immutable({
           service_order_id: '91',
           process: true
         }
-      ]
+      ],
+      configVmLength: 2,
+      infraMappingName: null,
+      scheduleTime: null,
+      status: 'Ok'
     },
     // PLAN F-0 APPROVED
     // |-- Request 1: active
@@ -306,7 +326,11 @@ export const transformationPlans = Immutable({
           service_order_id: '91',
           process: true
         }
-      ]
+      ],
+      configVmLength: 2,
+      infraMappingName: null,
+      scheduleTime: null,
+      status: 'Ok'
     }
   ]
 });

--- a/app/javascript/react/screens/App/common/getMostRecentRequest.js
+++ b/app/javascript/react/screens/App/common/getMostRecentRequest.js
@@ -1,4 +1,4 @@
 const getMostRecentRequest = requests =>
-  requests.reduce((prev, current) => (prev.created_on > current.created_on ? prev : current));
+  requests.length && requests.reduce((prev, current) => (prev.created_on > current.created_on ? prev : current));
 
 export default getMostRecentRequest;


### PR DESCRIPTION
fixes #496

All if my mappings have silly boring names... so that's why we have silly boring names...

### it looks like....
<img width="1372" alt="screen shot 2018-07-19 at 3 01 52 pm" src="https://user-images.githubusercontent.com/6640236/42964357-cd684528-8b64-11e8-8c79-0c4384d8e328.png">
<img width="1370" alt="screen shot 2018-07-19 at 3 01 43 pm" src="https://user-images.githubusercontent.com/6640236/42964358-cd74915c-8b64-11e8-9e07-d51ab12b8538.png">
<img width="1373" alt="screen shot 2018-07-19 at 3 01 34 pm" src="https://user-images.githubusercontent.com/6640236/42964359-cd889e22-8b64-11e8-846d-afadfc60c922.png">


~~Still thinkin' about this approach... seems silly to run the **exact same function** multiple times on pieces of a whole (the whole being transformationPlans)~~

~~BUT the highest (first) place `transformationPlans` and `transformationMappings` coexist is in `overview.js`, pass em both down to where we're turning things mutable... n here we go.....~~