### PR TITLE
[#505] OSP - Infra Mapping Wizard Step 1

### DIFF
--- a/app/javascript/components/index.js
+++ b/app/javascript/components/index.js
@@ -33,10 +33,13 @@ export const coreComponents = [
         '/api/clusters?expand=resources' +
         '&attributes=ext_management_system.emstype,v_parent_datacenter,ext_management_system.name' +
         '&filter[]=ext_management_system.emstype=vmwarews',
-      fetchTargetClustersUrl:
-        '/api/clusters?expand=resources' +
-        '&attributes=ext_management_system.emstype,v_parent_datacenter,ext_management_system.name' +
-        '&filter[]=ext_management_system.emstype=rhevm'
+      fetchTargetComputeUrls: {
+        rhevm:
+          '/api/clusters?expand=resources' +
+          '&attributes=ext_management_system.emstype,v_parent_datacenter,ext_management_system.name' +
+          '&filter[]=ext_management_system.emstype=rhevm',
+        openstack: '/api/cloud_tenants?expand=resources&attributes=ext_management_system.name'
+      }
     },
     store: true
   },

--- a/app/javascript/components/index.js
+++ b/app/javascript/components/index.js
@@ -47,7 +47,11 @@ export const coreComponents = [
     name: 'MappingWizardDatastoresStepContainer',
     type: MappingWizardDatastoresStepContainer,
     data: {
-      fetchDatastoresUrl: 'api/clusters'
+      fetchStoragesUrls: {
+        source: 'api/clusters',
+        rhevm: 'api/clusters',
+        openstack: 'api/cloud_tenants'
+      }
     },
     store: true
   },

--- a/app/javascript/components/index.js
+++ b/app/javascript/components/index.js
@@ -59,7 +59,11 @@ export const coreComponents = [
     name: 'MappingWizardNetworksStepContainer',
     type: MappingWizardNetworksStepContainer,
     data: {
-      fetchNetworksUrl: 'api/clusters'
+      fetchNetworksUrls: {
+        source: 'api/clusters',
+        rhevm: 'api/clusters',
+        openstack: 'api/cloud_tenants'
+      }
     },
     store: true
   },

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/MappingWizardBody.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/MappingWizardBody.js
@@ -35,17 +35,17 @@ class MappingWizardBody extends React.Component {
             disableGoto: !this.props.mappingWizardGeneralStep.values
           },
           {
-            title: __('Clusters'),
+            title: __('Map Compute'),
             render: () => this.mappingWizardClustersStepContainer,
             disableGoto: !this.props.mappingWizardClustersStep.values
           },
           {
-            title: __('Datastores'),
+            title: __('Map Storage'),
             render: () => this.mappingWizardDatastoresStepContainer,
             disableGoto: !this.props.mappingWizardDatastoresStep.values
           },
           {
-            title: __('Networks'),
+            title: __('Map Networks'),
             render: () => this.mappingWizardNetworksStepContainer,
             disableGoto: !this.props.mappingWizardNetworksStep.values
           },

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/MappingWizardConstants.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/MappingWizardConstants.js
@@ -3,3 +3,8 @@ export const V2V_SHOW_WARNING_MODAL = 'V2V_SHOW_WARNING_MODAL';
 export const V2V_HIDE_WARNING_MODAL = 'V2V_HIDE_WARNING_MODAL';
 export const V2V_SHOW_ALERT = 'V2V_SHOW_ALERT';
 export const V2V_HIDE_ALERT = 'V2V_HIDE_ALERT';
+
+export const V2V_TARGET_PROVIDERS = [
+  { name: __('Red Hat Virtualization'), id: 'rhevm' },
+  { name: __('Red Hat OpenStack Platform'), id: 'openstack' }
+];

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/__tests__/__snapshots__/index.test.js.snap
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/__tests__/__snapshots__/index.test.js.snap
@@ -9,23 +9,7 @@ Object {
   "mappingWizardClustersStep": Object {},
   "mappingWizardDatastoresStep": Object {},
   "mappingWizardExitedAction": [Function],
-  "mappingWizardGeneralStep": Object {
-    "registeredFields": Object {
-      "description": Object {
-        "count": 1,
-        "name": "description",
-        "type": "Field",
-      },
-      "name": Object {
-        "count": 1,
-        "name": "name",
-        "type": "Field",
-      },
-    },
-    "syncErrors": Object {
-      "name": "Required. Maximum length is %s characters.",
-    },
-  },
+  "mappingWizardGeneralStep": Object {},
   "mappingWizardNetworksStep": Object {},
   "setTransformationsBodyAction": [Function],
   "showAlertAction": [Function],

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/__tests__/index.test.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/__tests__/index.test.js
@@ -16,6 +16,8 @@ import componentRegistry from '../../../../../../../components/componentRegistry
 jest.mock('../../../../../../../components/componentRegistry');
 componentRegistry.registerMultiple(coreComponents);
 
+jest.mock('../components/MappingWizardGeneralStep/MappingWizardGeneralStep');
+
 describe('Mapping Wizard integration test', () => {
   const middlewares = [thunk, promiseMiddleware()];
   const generateStore = () =>

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStep.js
@@ -15,12 +15,13 @@ class MappingWizardClustersStep extends React.Component {
     const {
       fetchSourceClustersUrl,
       fetchSourceClustersAction,
-      fetchTargetClustersUrl,
-      fetchTargetClustersAction
+      fetchTargetComputeUrls,
+      fetchTargetClustersAction,
+      targetProvider
     } = this.props;
 
     fetchSourceClustersAction(fetchSourceClustersUrl);
-    fetchTargetClustersAction(fetchTargetClustersUrl);
+    fetchTargetClustersAction(fetchTargetComputeUrls[targetProvider]);
   };
 
   render() {
@@ -66,24 +67,26 @@ class MappingWizardClustersStep extends React.Component {
 MappingWizardClustersStep.propTypes = {
   fetchSourceClustersUrl: PropTypes.string,
   fetchSourceClustersAction: PropTypes.func,
-  fetchTargetClustersUrl: PropTypes.string,
+  fetchTargetComputeUrls: PropTypes.object,
   fetchTargetClustersAction: PropTypes.func,
   sourceClusters: PropTypes.arrayOf(PropTypes.object),
   targetClusters: PropTypes.arrayOf(PropTypes.object),
   isFetchingSourceClusters: PropTypes.bool,
   isFetchingTargetClusters: PropTypes.bool,
   isRejectedSourceClusters: PropTypes.bool,
-  isRejectedTargetClusters: PropTypes.bool
+  isRejectedTargetClusters: PropTypes.bool,
+  targetProvider: PropTypes.string
 };
 MappingWizardClustersStep.defaultProps = {
   fetchSourceClustersUrl: '',
   fetchSourceClustersAction: noop,
-  fetchTargetClustersUrl: '',
+  fetchTargetComputeUrls: {},
   fetchTargetClustersAction: noop,
   isFetchingSourceClusters: true,
   isFetchingTargetClusters: true,
   isRejectedSourceClusters: false,
-  isRejectedTargetClusters: false
+  isRejectedTargetClusters: false,
+  targetProvider: ''
 };
 
 export default reduxForm({

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/__tests__/__snapshots__/index.test.js.snap
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/__tests__/__snapshots__/index.test.js.snap
@@ -5,12 +5,16 @@ Object {
   "fetchSourceClustersAction": [Function],
   "fetchSourceClustersUrl": "/api/dummyProviders",
   "fetchTargetClustersAction": [Function],
-  "fetchTargetClustersUrl": "/api/dummyProviders",
+  "fetchTargetComputeUrls": Object {
+    "openstack": "/api/dummy",
+    "rhevm": "/api/dummy",
+  },
   "isFetchingSourceClusters": true,
   "isFetchingTargetClusters": true,
   "isRejectedSourceClusters": false,
   "isRejectedTargetClusters": false,
   "sourceClusters": Array [],
   "targetClusters": Array [],
+  "targetProvider": "rhevm",
 }
 `;

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/__tests__/index.test.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/__tests__/index.test.js
@@ -15,7 +15,8 @@ describe('Mapping Wizard integration test', () => {
     createStore(
       combineReducers({ ...reducers, form: formReducer }),
       {
-        mappingWizardClustersStep: initialState
+        mappingWizardClustersStep: initialState,
+        form: { mappingWizardGeneralStep: { values: { targetProvider: 'rhevm' } } }
       },
       applyMiddleware(...middlewares)
     );

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/index.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/index.js
@@ -6,9 +6,10 @@ import reducer from './MappingWizardClustersStepReducer';
 
 export const reducers = { mappingWizardClustersStep: reducer };
 
-const mapStateToProps = ({ mappingWizardClustersStep }, ownProps) => ({
+const mapStateToProps = ({ mappingWizardClustersStep, form }, ownProps) => ({
   ...mappingWizardClustersStep,
-  ...ownProps.data
+  ...ownProps.data,
+  targetProvider: form.mappingWizardGeneralStep.values.targetProvider
 });
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => Object.assign(stateProps, ownProps.data, dispatchProps);

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/mappingWizardClustersStep.fixtures.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/mappingWizardClustersStep.fixtures.js
@@ -151,5 +151,8 @@ export const initialState = Immutable({
   sourceClusters: [],
   targetClusters: [],
   fetchSourceClustersUrl: requestSourceClustersData.fetchSourceClustersUrl,
-  fetchTargetClustersUrl: requestTargetClustersData.fetchTargetClustersUrl
+  fetchTargetComputeUrls: {
+    rhevm: '/api/dummy',
+    openstack: '/api/dummy'
+  }
 });

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStep.js
@@ -57,10 +57,11 @@ class MappingWizardDatastoresStep extends React.Component {
     // when dropdown selection occurs for source cluster, we go retrieve the datastores for that
     // cluster
     const {
-      fetchDatastoresUrl,
+      fetchStoragesUrls,
       fetchSourceDatastoresAction,
       fetchTargetDatastoresAction,
-      clusterMappings
+      clusterMappings,
+      targetProvider
     } = this.props;
 
     const selectedClusterMapping = clusterMappings.find(clusterMapping =>
@@ -74,8 +75,8 @@ class MappingWizardDatastoresStep extends React.Component {
       selectedClusterMapping
     }));
 
-    fetchSourceDatastoresAction(fetchDatastoresUrl, sourceClusterId);
-    fetchTargetDatastoresAction(fetchDatastoresUrl, targetCluster.id);
+    fetchSourceDatastoresAction(fetchStoragesUrls.source, sourceClusterId);
+    fetchTargetDatastoresAction(fetchStoragesUrls[targetProvider], targetCluster.id, targetProvider);
   };
 
   render() {
@@ -134,7 +135,7 @@ class MappingWizardDatastoresStep extends React.Component {
 
 MappingWizardDatastoresStep.propTypes = {
   clusterMappings: PropTypes.array,
-  fetchDatastoresUrl: PropTypes.string,
+  fetchStoragesUrls: PropTypes.object,
   fetchSourceDatastoresAction: PropTypes.func,
   fetchTargetDatastoresAction: PropTypes.func,
   sourceDatastores: PropTypes.arrayOf(PropTypes.object),
@@ -145,11 +146,12 @@ MappingWizardDatastoresStep.propTypes = {
   isRejectedTargetDatastores: PropTypes.bool,
   form: PropTypes.string,
   pristine: PropTypes.bool,
-  showAlertAction: PropTypes.func
+  showAlertAction: PropTypes.func,
+  targetProvider: PropTypes.string
 };
 MappingWizardDatastoresStep.defaultProps = {
   clusterMappings: [],
-  fetchDatastoresUrl: '',
+  fetchStoragesUrls: {},
   fetchSourceDatastoresAction: noop,
   fetchTargetDatastoresAction: noop,
   sourceDatastores: [],
@@ -160,7 +162,8 @@ MappingWizardDatastoresStep.defaultProps = {
   isRejectedTargetDatastores: false,
   form: '',
   pristine: true,
-  showAlertAction: noop
+  showAlertAction: noop,
+  targetProvider: ''
 };
 
 export default reduxForm({

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepActions.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepActions.js
@@ -1,6 +1,10 @@
 import URI from 'urijs';
 import API from '../../../../../../../../common/API';
-import { FETCH_V2V_SOURCE_DATASTORES, FETCH_V2V_TARGET_DATASTORES } from './MappingWizardDatastoresStepConstants';
+import {
+  FETCH_V2V_SOURCE_DATASTORES,
+  FETCH_V2V_TARGET_DATASTORES,
+  QUERY_ATTRIBUTES
+} from './MappingWizardDatastoresStepConstants';
 
 const _filterSourceDatastores = response => {
   const { data } = response;
@@ -35,7 +39,7 @@ const _getSourceDatastoresActionCreator = url => dispatch =>
 export const fetchSourceDatastoresAction = (url, id) => {
   const uri = new URI(`${url}/${id}`);
   // creates url like: http://localhost:3000/api/clusters/1?attributes=storages
-  uri.addSearch({ attributes: 'storages,ext_management_system.name' });
+  uri.addSearch({ attributes: QUERY_ATTRIBUTES.source });
 
   return _getSourceDatastoresActionCreator(uri.toString());
 };
@@ -68,10 +72,10 @@ const _getTargetDatastoresActionCreator = url => dispatch =>
     })
   });
 
-export const fetchTargetDatastoresAction = (url, id) => {
+export const fetchTargetDatastoresAction = (url, id, targetProvider) => {
   const uri = new URI(`${url}/${id}`);
   // creates url like: http://localhost:3000/api/clusters/1?attributes=storages
-  uri.addSearch({ attributes: 'storages,ext_management_system.name' });
+  uri.addSearch({ attributes: QUERY_ATTRIBUTES[targetProvider] });
 
   return _getTargetDatastoresActionCreator(uri.toString());
 };

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepConstants.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepConstants.js
@@ -1,2 +1,8 @@
 export const FETCH_V2V_SOURCE_DATASTORES = 'FETCH_V2V_SOURCE_DATASTORES';
 export const FETCH_V2V_TARGET_DATASTORES = 'FETCH_V2V_TARGET_DATASTORES';
+
+export const QUERY_ATTRIBUTES = {
+  source: 'storages,ext_management_system.name',
+  rhevm: 'storages,ext_management_system.name',
+  openstack: 'cloud_volumes,ext_management_system.name'
+};

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/index.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/index.js
@@ -10,7 +10,8 @@ export const reducers = { mappingWizardDatastoresStep: reducer };
 const mapStateToProps = ({ mappingWizardDatastoresStep, form }, ownProps) => ({
   ...mappingWizardDatastoresStep,
   ...ownProps.data,
-  clusterMappings: form.mappingWizardClustersStep.values.clusterMappings
+  clusterMappings: form.mappingWizardClustersStep.values.clusterMappings,
+  targetProvider: form.mappingWizardGeneralStep.values.targetProvider
 });
 
 const actions = {

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardGeneralStep/MappingWizardGeneralStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardGeneralStep/MappingWizardGeneralStep.js
@@ -46,6 +46,7 @@ const MappingWizardGeneralStep = props => (
       labelWidth={2}
       controlWidth={9}
       inline_label
+      style={{ visibility: 'hidden' }}
     />
   </Form>
 );

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardGeneralStep/MappingWizardGeneralStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardGeneralStep/MappingWizardGeneralStep.js
@@ -1,7 +1,8 @@
 import React from 'react';
-import { reduxForm, Field } from 'redux-form';
+import PropTypes from 'prop-types';
+import { reduxForm, Field, reset } from 'redux-form';
 import { required } from 'redux-form-validators';
-import { Form } from 'patternfly-react';
+import { Form, noop } from 'patternfly-react';
 
 import { FormField } from '../../../../../common/forms/FormField';
 import { BootstrapSelect } from '../../../../../common/forms/BootstrapSelect';
@@ -9,47 +10,68 @@ import { validation } from '../../../../../../../../common/constants';
 import { V2V_TARGET_PROVIDERS } from '../../MappingWizardConstants';
 import { asyncValidate, onChange } from '../helpers';
 
-const MappingWizardGeneralStep = props => (
-  <Form className="form-horizontal">
-    <Field
-      name="name"
-      label={__('Name')}
-      required
-      component={FormField}
-      type="text"
-      help={validation.name.help}
-      maxLength={validation.name.maxLength}
-      maxLengthWarning={validation.name.maxLengthWarning}
-      validate={[
-        required({
-          msg: validation.name.requiredMessage
-        })
-      ]}
-    />
-    <Field
-      name="description"
-      label={__('Description')}
-      component={FormField}
-      type="textarea"
-      help={validation.description.help}
-      maxLength={validation.description.maxLength}
-      maxLengthWarning={validation.description.maxLengthWarning}
-    />
-    <Field
-      name="targetProvider"
-      label={__('Target Provider')}
-      component={BootstrapSelect}
-      options={V2V_TARGET_PROVIDERS}
-      option_key="id"
-      option_value="name"
-      pre_selected_value={V2V_TARGET_PROVIDERS[0].id}
-      labelWidth={2}
-      controlWidth={9}
-      inline_label
-      style={{ visibility: 'hidden' }}
-    />
-  </Form>
-);
+const MappingWizardGeneralStep = props => {
+  const onSelect = selection => {
+    const { targetProvider, dispatch } = props;
+    if (targetProvider !== selection) {
+      dispatch(reset('mappingWizardClustersStep'));
+      dispatch(reset('mappingWizardDatastoresStep'));
+      dispatch(reset('mappingWizardNetworksStep'));
+    }
+  };
+  return (
+    <Form className="form-horizontal">
+      <Field
+        name="name"
+        label={__('Name')}
+        required
+        component={FormField}
+        type="text"
+        help={validation.name.help}
+        maxLength={validation.name.maxLength}
+        maxLengthWarning={validation.name.maxLengthWarning}
+        validate={[
+          required({
+            msg: validation.name.requiredMessage
+          })
+        ]}
+      />
+      <Field
+        name="description"
+        label={__('Description')}
+        component={FormField}
+        type="textarea"
+        help={validation.description.help}
+        maxLength={validation.description.maxLength}
+        maxLengthWarning={validation.description.maxLengthWarning}
+      />
+      <Field
+        name="targetProvider"
+        label={__('Target Provider')}
+        component={BootstrapSelect}
+        options={V2V_TARGET_PROVIDERS}
+        option_key="id"
+        option_value="name"
+        pre_selected_value={V2V_TARGET_PROVIDERS[0].id}
+        labelWidth={2}
+        controlWidth={9}
+        inline_label
+        onSelect={onSelect}
+        style={{ visibility: 'hidden' }}
+      />
+    </Form>
+  );
+};
+
+MappingWizardGeneralStep.propTypes = {
+  targetProvider: PropTypes.string,
+  dispatch: PropTypes.func
+};
+
+MappingWizardGeneralStep.defaultProps = {
+  targetProvider: 'rhevm',
+  dispatch: noop
+};
 
 // Decorate with reduxForm(). It will read the initialValues prop provided by connect()
 export default reduxForm({

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardGeneralStep/MappingWizardGeneralStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardGeneralStep/MappingWizardGeneralStep.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Field } from 'redux-form';
+import { reduxForm, Field } from 'redux-form';
 import { required } from 'redux-form-validators';
 import { Form } from 'patternfly-react';
 
@@ -7,6 +7,7 @@ import { FormField } from '../../../../../common/forms/FormField';
 import { BootstrapSelect } from '../../../../../common/forms/BootstrapSelect';
 import { validation } from '../../../../../../../../common/constants';
 import { V2V_TARGET_PROVIDERS } from '../../MappingWizardConstants';
+import { asyncValidate, onChange } from '../helpers';
 
 const MappingWizardGeneralStep = props => (
   <Form className="form-horizontal">
@@ -49,4 +50,12 @@ const MappingWizardGeneralStep = props => (
   </Form>
 );
 
-export default MappingWizardGeneralStep;
+// Decorate with reduxForm(). It will read the initialValues prop provided by connect()
+export default reduxForm({
+  form: 'mappingWizardGeneralStep', // a unique identifier for this form
+  destroyOnUnmount: false, // preserve form data
+  asyncValidate,
+  asyncBlurFields: ['name'],
+  onChange
+  // forceUnregisterOnUnmount: true, // unregister fields on unmount
+})(MappingWizardGeneralStep);

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardGeneralStep/MappingWizardGeneralStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardGeneralStep/MappingWizardGeneralStep.js
@@ -2,8 +2,11 @@ import React from 'react';
 import { Field } from 'redux-form';
 import { required } from 'redux-form-validators';
 import { Form } from 'patternfly-react';
+
 import { FormField } from '../../../../../common/forms/FormField';
-import { validation } from '../../../../../../../../common/constants'; // Oh my
+import { BootstrapSelect } from '../../../../../common/forms/BootstrapSelect';
+import { validation } from '../../../../../../../../common/constants';
+import { V2V_TARGET_PROVIDERS } from '../../MappingWizardConstants';
 
 const MappingWizardGeneralStep = props => (
   <Form className="form-horizontal">
@@ -30,6 +33,18 @@ const MappingWizardGeneralStep = props => (
       help={validation.description.help}
       maxLength={validation.description.maxLength}
       maxLengthWarning={validation.description.maxLengthWarning}
+    />
+    <Field
+      name="targetProvider"
+      label={__('Target Provider')}
+      component={BootstrapSelect}
+      options={V2V_TARGET_PROVIDERS}
+      option_key="id"
+      option_value="name"
+      pre_selected_value={V2V_TARGET_PROVIDERS[0].id}
+      labelWidth={2}
+      controlWidth={9}
+      inline_label
     />
   </Form>
 );

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardGeneralStep/index.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardGeneralStep/index.js
@@ -2,8 +2,10 @@ import { connect } from 'react-redux';
 import MappingWizardGeneralStep from './MappingWizardGeneralStep';
 import { showAlertAction, hideAlertAction } from '../../MappingWizardActions';
 
-const mapStateToProps = ({ overview: { transformationMappings } }) => ({
-  transformationMappings
+const mapStateToProps = ({ overview: { transformationMappings }, form: { mappingWizardGeneralStep } }) => ({
+  transformationMappings,
+  targetProvider:
+    mappingWizardGeneralStep && mappingWizardGeneralStep.values && mappingWizardGeneralStep.values.targetProvider
 });
 
 const actions = { showAlertAction, hideAlertAction };

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardGeneralStep/index.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardGeneralStep/index.js
@@ -1,19 +1,6 @@
 import { connect } from 'react-redux';
-import { reduxForm } from 'redux-form';
 import MappingWizardGeneralStep from './MappingWizardGeneralStep';
 import { showAlertAction, hideAlertAction } from '../../MappingWizardActions';
-
-import { asyncValidate, onChange } from './helpers';
-
-// Decorate with reduxForm(). It will read the initialValues prop provided by connect()
-const MappingWizardGeneralStepForm = reduxForm({
-  form: 'mappingWizardGeneralStep', // a unique identifier for this form
-  destroyOnUnmount: false, // preserve form data
-  asyncValidate,
-  asyncBlurFields: ['name'],
-  onChange
-  // forceUnregisterOnUnmount: true, // unregister fields on unmount
-})(MappingWizardGeneralStep);
 
 const mapStateToProps = ({ overview: { transformationMappings } }) => ({
   transformationMappings
@@ -24,4 +11,4 @@ const actions = { showAlertAction, hideAlertAction };
 export default connect(
   mapStateToProps,
   actions
-)(MappingWizardGeneralStepForm);
+)(MappingWizardGeneralStep);

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStep.js
@@ -57,7 +57,13 @@ class MappingWizardNetworksStep extends React.Component {
   selectSourceCluster = sourceClusterId => {
     // when dropdown selection occurs for source cluster, we go retrieve the
     // newworks for that cluster
-    const { fetchNetworksUrl, fetchSourceNetworksAction, fetchTargetNetworksAction, clusterMappings } = this.props;
+    const {
+      fetchNetworksUrls,
+      fetchSourceNetworksAction,
+      fetchTargetNetworksAction,
+      clusterMappings,
+      targetProvider
+    } = this.props;
 
     const selectedClusterMapping = clusterMappings.find(clusterMapping =>
       clusterMapping.nodes.some(sourceCluster => sourceCluster.id === sourceClusterId)
@@ -70,8 +76,8 @@ class MappingWizardNetworksStep extends React.Component {
       selectedClusterMapping
     }));
 
-    fetchSourceNetworksAction(fetchNetworksUrl, sourceClusterId);
-    fetchTargetNetworksAction(fetchNetworksUrl, targetCluster.id);
+    fetchSourceNetworksAction(fetchNetworksUrls.source, sourceClusterId);
+    fetchTargetNetworksAction(fetchNetworksUrls[targetProvider], targetCluster.id, targetProvider);
   };
 
   render() {
@@ -125,7 +131,7 @@ class MappingWizardNetworksStep extends React.Component {
 
 MappingWizardNetworksStep.propTypes = {
   clusterMappings: PropTypes.array,
-  fetchNetworksUrl: PropTypes.string,
+  fetchNetworksUrls: PropTypes.object,
   fetchSourceNetworksAction: PropTypes.func,
   fetchTargetNetworksAction: PropTypes.func,
   isFetchingSourceNetworks: PropTypes.bool,
@@ -136,11 +142,12 @@ MappingWizardNetworksStep.propTypes = {
   pristine: PropTypes.bool,
   showAlertAction: PropTypes.func,
   groupedSourceNetworks: PropTypes.object,
-  groupedTargetNetworks: PropTypes.object
+  groupedTargetNetworks: PropTypes.object,
+  targetProvider: PropTypes.string
 };
 MappingWizardNetworksStep.defaultProps = {
   clusterMappings: [],
-  fetchNetworksUrl: '',
+  fetchNetworksUrls: {},
   fetchSourceNetworksAction: noop,
   fetchTargetNetworksAction: noop,
   isFetchingSourceNetworks: false,
@@ -149,7 +156,8 @@ MappingWizardNetworksStep.defaultProps = {
   isRejectedTargetNetworks: false,
   form: '',
   pristine: true,
-  showAlertAction: noop
+  showAlertAction: noop,
+  targetProvider: ''
 };
 
 export default reduxForm({

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStepActions.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStepActions.js
@@ -1,6 +1,10 @@
 import URI from 'urijs';
 import API from '../../../../../../../../common/API';
-import { FETCH_V2V_SOURCE_NETWORKS, FETCH_V2V_TARGET_NETWORKS } from './MappingWizardNetworksStepConstants';
+import {
+  FETCH_V2V_SOURCE_NETWORKS,
+  FETCH_V2V_TARGET_NETWORKS,
+  QUERY_ATTRIBUTES
+} from './MappingWizardNetworksStepConstants';
 
 const _filterSourceNetworks = response => {
   const { data } = response;
@@ -36,7 +40,7 @@ const _getSourceNetworksActionCreator = url => dispatch =>
 export const fetchSourceNetworksAction = (url, id) => {
   const uri = new URI(`${url}/${id}`);
   // creates url like: http://localhost:3000/api/clusters/1?attributes=lans
-  uri.addSearch({ attributes: 'lans,ext_management_system.name' });
+  uri.addSearch({ attributes: QUERY_ATTRIBUTES.source });
 
   return _getSourceNetworksActionCreator(uri.toString());
 };
@@ -72,10 +76,10 @@ const _getTargetNetworksActionCreator = url => dispatch =>
     })
   });
 
-export const fetchTargetNetworksAction = (url, id) => {
+export const fetchTargetNetworksAction = (url, id, targetProvider) => {
   const uri = new URI(`${url}/${id}`);
   // creates url like: http://localhost:3000/api/clusters/1?attributes=lans
-  uri.addSearch({ attributes: 'lans,ext_management_system.name' });
+  uri.addSearch({ attributes: QUERY_ATTRIBUTES[targetProvider] });
 
   return _getTargetNetworksActionCreator(uri.toString());
 };

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStepConstants.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/MappingWizardNetworksStepConstants.js
@@ -1,2 +1,8 @@
 export const FETCH_V2V_SOURCE_NETWORKS = 'FETCH_V2V_SOURCE_NETWORKS';
 export const FETCH_V2V_TARGET_NETWORKS = 'FETCH_V2V_TARGET_NETWORKS';
+
+export const QUERY_ATTRIBUTES = {
+  source: 'lans,ext_management_system.name',
+  rhevm: 'lans,ext_management_system.name',
+  openstack: 'cloud_networks,ext_management_system.name'
+};

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/index.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/index.js
@@ -13,7 +13,8 @@ const mapStateToProps = ({ mappingWizardNetworksStep, form }, ownProps) => ({
   ...ownProps.data,
   clusterMappings: form.mappingWizardClustersStep.values.clusterMappings,
   groupedSourceNetworks: uniqueNetworks(mappingWizardNetworksStep.sourceNetworks),
-  groupedTargetNetworks: uniqueNetworks(mappingWizardNetworksStep.targetNetworks)
+  groupedTargetNetworks: uniqueNetworks(mappingWizardNetworksStep.targetNetworks),
+  targetProvider: form.mappingWizardGeneralStep.values.targetProvider
 });
 
 const actions = {

--- a/app/javascript/react/screens/App/common/forms/BootstrapSelect.js
+++ b/app/javascript/react/screens/App/common/forms/BootstrapSelect.js
@@ -13,6 +13,10 @@ export class BootstrapSelect extends React.Component {
       pre_selected_value
     } = this.props;
 
+    if (pre_selected_value) {
+      input.onChange(pre_selected_value);
+    }
+
     $(`#${input.name}`).selectpicker('val', input.value || pre_selected_value);
 
     $(`.${input.name}_select`).on('click', '.dropdown-toggle', e => {


### PR DESCRIPTION
Fixes #505 

* Add dropdown for target provider selection (hide for now)
* Update Wizard Step naming
* Set up API endpoints for fetching compute, storages, and networks (both RHV and OSP)
* Clear compute, storages, and networks steps if target provider is changed

_**Additional Changes**_
* Dispatch onChange if BootstrapSelect is provided a default value
# Notes
1.  Scaffolds fetching OSP related data (compute, storages, networks)
    - Some `actions/action creators/reducers` may or may not still need to be updated (to be handled in issues #506, #507, #508)
    - API endpoints need to be confirmed
    - Using the test db, these endpoints will return data that can be used for UI development.  Since we only display basic attributes (`name`, `ext_management_system.name`, etc), it should, in theory, be ok if the model changes
    - Use this query to see which OSP `cloud_tenants` have `cloud_volumes` and `cloud_networks`

      http://localhost:3000/api/cloud_tenants?expand=resources&attributes=cloud_volumes,cloud_networks
2.  Allows the remaining steps to be developed in parallel while (hopefully) minimizing merge conflicts.
3.  Target Provider dropdown will be hidden from view (using CSS) until all steps are ready to be, or have been, merged.  Dev can make the dropdown visible while working on the issues by commenting out [this line](https://github.com/ManageIQ/miq_v2v_ui_plugin/pull/510/files#diff-f62459b84c7fdf0c959a7f02e7f2c2efR60)
4.  Migrating VMWare -> RHV still works as before without the dropdown being visible, i.e., this PR does not interfere with current functionality

# Screens (with dropdown visible)
<img width="1920" alt="fullscreen_7_20_18__9_40_am" src="https://user-images.githubusercontent.com/15141412/43005472-f28d4c26-8c00-11e8-865e-a2bef6862c52.png">

<img width="1920" alt="fullscreen_7_20_18__9_40_am" src="https://user-images.githubusercontent.com/15141412/43005492-08bb9066-8c01-11e8-8878-eb9185fdee18.png">

<img width="1920" alt="fullscreen_7_20_18__9_41_am" src="https://user-images.githubusercontent.com/15141412/43005535-2d8c33c8-8c01-11e8-833a-6bb98c4c0975.png">

# Screens (OSP)
## Map Compute
<img width="1920" alt="cloud_tenants" src="https://user-images.githubusercontent.com/15141412/43399385-db0b354c-93d8-11e8-90f3-8a3db93ea958.png">

## `cloud_volumes`  (Need additional changes in order for these to show up in selector in Storages Step)
<img width="626" alt="devtools_-_localhost_8080_migration" src="https://user-images.githubusercontent.com/15141412/43399547-57b5feb0-93d9-11e8-8491-eb4602d3473d.png">
