### PR TITLE
[#515]Adds migration scheduling to complete mapping list

### DIFF
--- a/app/javascript/react/screens/App/Overview/Overview.js
+++ b/app/javascript/react/screens/App/Overview/Overview.js
@@ -242,7 +242,7 @@ class Overview extends React.Component {
       isRejectedDatastores,
       toggleScheduleMigrationModal,
       scheduleMigrationModal,
-      scheduleMigrationPlanId,
+      scheduleMigrationPlan,
       scheduleMigration
     } = this.props;
 
@@ -330,7 +330,7 @@ class Overview extends React.Component {
               addNotificationAction={addNotificationAction}
               toggleScheduleMigrationModal={toggleScheduleMigrationModal}
               scheduleMigrationModal={scheduleMigrationModal}
-              scheduleMigrationPlanId={scheduleMigrationPlanId}
+              scheduleMigrationPlan={scheduleMigrationPlan}
               scheduleMigration={scheduleMigration}
             />
           )}
@@ -458,7 +458,7 @@ Overview.propTypes = {
   fetchDatastoresAction: PropTypes.func,
   toggleScheduleMigrationModal: PropTypes.func,
   scheduleMigrationModal: PropTypes.bool,
-  scheduleMigrationPlanId: PropTypes.string,
+  scheduleMigrationPlan: PropTypes.object,
   scheduleMigration: PropTypes.func,
   fetchServiceTemplateAnsiblePlaybooksAction: PropTypes.func,
   fetchServiceTemplateAnsiblePlaybooksUrl: PropTypes.string,

--- a/app/javascript/react/screens/App/Overview/OverviewActions.js
+++ b/app/javascript/react/screens/App/Overview/OverviewActions.js
@@ -245,31 +245,41 @@ export const archiveTransformationPlanAction = (url, id) => {
   return _archiveTransformationPlanActionCreator(uri.toString());
 };
 
-export const toggleScheduleMigrationModal = planId => ({
+export const toggleScheduleMigrationModal = plan => ({
   type: V2V_TOGGLE_SCHEDULE_MIGRATION_MODAL,
-  payload: planId
+  payload: plan
 });
 
 export const scheduleMigration = payload => dispatch =>
   dispatch({
     type: V2V_SCHEDULE_MIGRATION,
     payload: new Promise((resolve, reject) => {
-      let url = `/api/service_templates/${payload.planId}`;
+      const {
+        scheduleTime,
+        plan: { id: planId }
+      } = payload;
+      const scheduleId = (payload.plan.schedules && payload.plan.schedules[0].id) || null;
+      let url = `/api/service_templates/${planId}`;
       let body = {
         action: 'order',
         resource: {
-          schedule_time: payload.scheduleTime
+          schedule_time: scheduleTime
         }
       };
-      if (payload.scheduleId) {
-        url = `${url}/schedules/${payload.scheduleId}`;
-        body = { action: 'delete' };
+      if (scheduleId) {
+        url = `${url}/schedules/${scheduleId}`;
+        body = scheduleTime
+          ? {
+              action: 'edit',
+              resource: { run_at: { ...payload.plan.schedules[0].run_at, start_time: scheduleTime } }
+            }
+          : { action: 'delete' };
       }
       return API.post(url, body)
         .then(response => {
           resolve(response);
           let msg = __('Migration successfully unscheduled');
-          if (payload.scheduleTime) {
+          if (scheduleTime) {
             msg = sprintf(
               __('Migration successfully scheduled for %s'),
               formatDateTime(response.data.run_at.start_time)

--- a/app/javascript/react/screens/App/Overview/OverviewReducer.js
+++ b/app/javascript/react/screens/App/Overview/OverviewReducer.js
@@ -100,7 +100,7 @@ export const initialState = Immutable({
   isFetchingNetworks: false,
   isRejectedNetworks: false,
   scheduleMigrationModal: false,
-  scheduleMigrationPlanId: null,
+  scheduleMigrationPlan: {},
   isSchedulingMigration: false,
   isRejectedSchedulingMigration: false,
   errorSchedulingMigration: false,
@@ -382,10 +382,10 @@ export default (state = initialState, action) => {
     case V2V_TOGGLE_SCHEDULE_MIGRATION_MODAL:
       if (action.payload !== undefined) {
         return state
-          .set('scheduleMigrationPlanId', action.payload.planId)
+          .set('scheduleMigrationPlan', action.payload.plan)
           .set('scheduleMigrationModal', !state.scheduleMigrationModal);
       }
-      return state.set('scheduleMigrationPlanId', null).set('scheduleMigrationModal', !state.scheduleMigrationModal);
+      return state.set('scheduleMigrationPlan', null).set('scheduleMigrationModal', !state.scheduleMigrationModal);
     case `${V2V_SCHEDULE_MIGRATION}_PENDING`:
       return state.set('isSchedulingMigration', true).set('isRejectedSchedulingMigration', false);
     case `${V2V_SCHEDULE_MIGRATION}_FULFILLED`:

--- a/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/Migrations.js
@@ -35,7 +35,7 @@ const Migrations = ({
   addNotificationAction,
   toggleScheduleMigrationModal,
   scheduleMigrationModal,
-  scheduleMigrationPlanId,
+  scheduleMigrationPlan,
   scheduleMigration
 }) => {
   const filterOptions = [
@@ -113,7 +113,7 @@ const Migrations = ({
               hideConfirmModalAction={hideConfirmModalAction}
               toggleScheduleMigrationModal={toggleScheduleMigrationModal}
               scheduleMigrationModal={scheduleMigrationModal}
-              scheduleMigrationPlanId={scheduleMigrationPlanId}
+              scheduleMigrationPlan={scheduleMigrationPlan}
               scheduleMigration={scheduleMigration}
               fetchTransformationPlansAction={fetchTransformationPlansAction}
               fetchTransformationPlansUrl={fetchTransformationPlansUrl}
@@ -143,6 +143,10 @@ const Migrations = ({
               fetchTransformationPlansAction={fetchTransformationPlansAction}
               fetchTransformationPlansUrl={fetchTransformationPlansUrl}
               addNotificationAction={addNotificationAction}
+              toggleScheduleMigrationModal={toggleScheduleMigrationModal}
+              scheduleMigrationModal={scheduleMigrationModal}
+              scheduleMigrationPlan={scheduleMigrationPlan}
+              scheduleMigration={scheduleMigration}
             />
           )}
           {activeFilter === MIGRATIONS_FILTERS.archived && (
@@ -187,7 +191,7 @@ Migrations.propTypes = {
   addNotificationAction: PropTypes.func,
   toggleScheduleMigrationModal: PropTypes.func,
   scheduleMigrationModal: PropTypes.bool,
-  scheduleMigrationPlanId: PropTypes.string,
+  scheduleMigrationPlan: PropTypes.object,
   scheduleMigration: PropTypes.func
 };
 Migrations.defaultProps = {

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { noop, Button, ListView, Grid, Spinner, Icon, Toolbar, Sort } from 'patternfly-react';
+import { noop, Button, ListView, Grid, Spinner, Icon, Toolbar, Sort, DropdownKebab, MenuItem } from 'patternfly-react';
 import { IsoElapsedTime } from '../../../../../../components/dates/IsoElapsedTime';
 import OverviewEmptyState from '../OverviewEmptyState/OverviewEmptyState';
 import getMostRecentRequest from '../../../common/getMostRecentRequest';
@@ -243,7 +243,8 @@ class MigrationsCompletedList extends React.Component {
                         ]}
                         actions={
                           !archived && (
-                            <React.Fragment>
+                            <div onClick={e => e.stopPropagation()} // eslint-disable-line
+                            >
                               {failed && (
                                 <React.Fragment>
                                   <ScheduleMigrationButton
@@ -267,15 +268,17 @@ class MigrationsCompletedList extends React.Component {
                                   </Button>
                                 </React.Fragment>
                               )}
-                              <Button
-                                onClick={e => {
-                                  e.stopPropagation();
-                                  showConfirmModalAction(confirmModalOptions);
-                                }}
-                              >
-                                {__('Archive')}
-                              </Button>
-                            </React.Fragment>
+                              <DropdownKebab id={`${plan.id}-kebab`} pullRight>
+                                <MenuItem
+                                  onClick={e => {
+                                    e.stopPropagation();
+                                    showConfirmModalAction(confirmModalOptions);
+                                  }}
+                                >
+                                  {__('Archive')}
+                                </MenuItem>
+                              </DropdownKebab>
+                            </div>
                           )
                         }
                       />

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsCompletedList.js
@@ -7,6 +7,9 @@ import getMostRecentRequest from '../../../common/getMostRecentRequest';
 import getMostRecentVMTasksFromRequests from './helpers/getMostRecentVMTasksFromRequests';
 import sortFilter from '../../../Plan/components/sortFilter';
 import { MIGRATIONS_COMPLETED_SORT_FIELDS } from './MigrationsConstants';
+import ScheduleMigrationButton from './ScheduleMigrationButton';
+import ScheduleMigrationModal from '../ScheduleMigrationModal/ScheduleMigrationModal';
+import { formatDateTime } from '../../../../../../components/dates/MomentDate';
 
 class MigrationsCompletedList extends React.Component {
   state = {
@@ -55,217 +58,257 @@ class MigrationsCompletedList extends React.Component {
       fetchTransformationPlansAction,
       fetchTransformationPlansUrl,
       addNotificationAction,
-      archived
+      archived,
+      toggleScheduleMigrationModal,
+      scheduleMigrationModal,
+      scheduleMigrationPlan,
+      scheduleMigration
     } = this.props;
     const sortedMigrations = this.sortedMigrations();
 
     return (
-      <Grid.Col xs={12}>
-        <Spinner loading={!!loading}>
-          {finishedTransformationPlans.length > 0 ? (
-            <React.Fragment>
-              {!archived && (
-                <React.Fragment>
-                  <Grid.Row>
-                    <Toolbar>
-                      <Sort>
-                        <Sort.TypeSelector
-                          sortTypes={sortFields}
-                          currentSortType={currentSortType}
-                          onSortTypeSelected={this.updateCurrentSortType}
-                        />
-                        <Sort.DirectionSelector
-                          isNumeric={isSortNumeric}
-                          isAscending={isSortAscending}
-                          onClick={this.toggleCurrentSortDirection}
-                        />
-                      </Sort>
-                    </Toolbar>
-                  </Grid.Row>
-                </React.Fragment>
-              )}
-              <ListView className="plans-complete-list" style={{ marginTop: 0 }}>
-                {sortedMigrations.map(plan => {
-                  const requestsOfAssociatedPlan = allRequestsWithTasks.filter(
-                    request => request.source_id === plan.id
-                  );
+      <React.Fragment>
+        <Grid.Col xs={12}>
+          <Spinner loading={!!loading}>
+            {finishedTransformationPlans.length > 0 ? (
+              <React.Fragment>
+                {!archived && (
+                  <React.Fragment>
+                    <Grid.Row>
+                      <Toolbar>
+                        <Sort>
+                          <Sort.TypeSelector
+                            sortTypes={sortFields}
+                            currentSortType={currentSortType}
+                            onSortTypeSelected={this.updateCurrentSortType}
+                          />
+                          <Sort.DirectionSelector
+                            isNumeric={isSortNumeric}
+                            isAscending={isSortAscending}
+                            onClick={this.toggleCurrentSortDirection}
+                          />
+                        </Sort>
+                      </Toolbar>
+                    </Grid.Row>
+                  </React.Fragment>
+                )}
+                <ListView className="plans-complete-list" style={{ marginTop: 0 }}>
+                  {sortedMigrations.map(plan => {
+                    const migrationScheduled = plan.schedules && plan.schedules[0].run_at.start_time;
+                    const staleMigrationSchedule = (new Date(migrationScheduled).getTime() || 0) < Date.now();
 
-                  const mostRecentRequest =
-                    requestsOfAssociatedPlan.length > 0 && getMostRecentRequest(requestsOfAssociatedPlan);
-
-                  const failed = mostRecentRequest && mostRecentRequest.status === 'Error';
-
-                  const tasks = {};
-                  let tasksOfPlan = {};
-                  if (requestsOfAssociatedPlan.length > 0) {
-                    tasksOfPlan = getMostRecentVMTasksFromRequests(
-                      requestsOfAssociatedPlan,
-                      plan.options.config_info.actions
+                    const requestsOfAssociatedPlan = allRequestsWithTasks.filter(
+                      request => request.source_id === plan.id
                     );
-                    tasksOfPlan.forEach(task => {
-                      tasks[task.source_id] = task.status === 'Ok';
-                    });
-                  } else if (mostRecentRequest) {
-                    mostRecentRequest.miq_request_tasks.forEach(task => {
-                      tasks[task.source_id] = task.status === 'Ok';
-                    });
-                  }
-                  let succeedCount = 0;
-                  Object.keys(tasks).forEach(key => {
-                    if (tasks[key]) succeedCount += 1;
-                  });
 
-                  const elapsedTime = IsoElapsedTime(
-                    new Date(mostRecentRequest && mostRecentRequest.options.delivered_on),
-                    new Date(mostRecentRequest && mostRecentRequest.fulfilled_on)
-                  );
+                    const mostRecentRequest =
+                      requestsOfAssociatedPlan.length > 0 && getMostRecentRequest(requestsOfAssociatedPlan);
 
-                  const archiveMigrationWarningText = (
-                    <React.Fragment>
-                      <p>
-                        {__('Are you sure you want to archive migration plan ')}
-                        <strong>{plan.name}</strong>?
-                      </p>
-                      {failed && (
-                        <p>
-                          {__('This plan includes VMs that failed to migrate. If you archive the plan, you will not be able to retry the failed migrations.') // prettier-ignore
-                          }
-                        </p>
-                      )}
-                    </React.Fragment>
-                  );
+                    const failed = mostRecentRequest && mostRecentRequest.status === 'Error';
 
-                  const confirmModalBaseProps = {
-                    title: __('Archive Migration Plan'),
-                    body: archiveMigrationWarningText,
-                    icon: failed && <Icon className="confirm-warning-icon" type="pf" name="warning-triangle-o" />,
-                    confirmButtonLabel: __('Archive')
-                  };
-
-                  const onConfirm = () => {
-                    showConfirmModalAction({
-                      ...confirmModalBaseProps,
-                      disableCancelButton: true,
-                      disableConfirmButton: true
-                    });
-                    archiveTransformationPlanAction(archiveTransformationPlanUrl, plan.id)
-                      .then(() => {
-                        addNotificationAction({
-                          message: sprintf(__('%s successfully archived'), plan.name),
-                          notificationType: 'success',
-                          persistent: false
-                        });
-
-                        return fetchTransformationPlansAction({
-                          url: fetchTransformationPlansUrl,
-                          archived: false
-                        });
-                      })
-                      .then(() => {
-                        hideConfirmModalAction();
+                    const tasks = {};
+                    let tasksOfPlan = {};
+                    if (requestsOfAssociatedPlan.length > 0) {
+                      tasksOfPlan = getMostRecentVMTasksFromRequests(
+                        requestsOfAssociatedPlan,
+                        plan.options.config_info.actions
+                      );
+                      tasksOfPlan.forEach(task => {
+                        tasks[task.source_id] = task.status === 'Ok';
                       });
-                  };
+                    } else if (mostRecentRequest) {
+                      mostRecentRequest.miq_request_tasks.forEach(task => {
+                        tasks[task.source_id] = task.status === 'Ok';
+                      });
+                    }
+                    let succeedCount = 0;
+                    Object.keys(tasks).forEach(key => {
+                      if (tasks[key]) succeedCount += 1;
+                    });
 
-                  const confirmModalOptions = {
-                    ...confirmModalBaseProps,
-                    onConfirm
-                  };
+                    const elapsedTime = IsoElapsedTime(
+                      new Date(mostRecentRequest && mostRecentRequest.options.delivered_on),
+                      new Date(mostRecentRequest && mostRecentRequest.fulfilled_on)
+                    );
 
-                  return (
-                    <ListView.Item
-                      stacked
-                      className="plans-complete-list__list-item"
-                      onClick={() => {
-                        redirectTo(`/migration/plan/${plan.id}`);
-                      }}
-                      key={plan.id}
-                      leftContent={
-                        archived ? (
-                          <ListView.Icon
-                            type="fa"
-                            name="archive"
-                            size="md"
-                            style={{
-                              width: 'inherit',
-                              backgroundColor: 'transparent',
-                              border: 'none'
-                            }}
-                          />
-                        ) : (
-                          <ListView.Icon
-                            type="pf"
-                            name={failed ? 'error-circle-o' : 'ok'}
-                            size="md"
-                            style={{
-                              width: 'inherit',
-                              backgroundColor: 'transparent'
-                            }}
-                          />
-                        )
-                      }
-                      heading={plan.name}
-                      description={plan.description}
-                      additionalInfo={[
-                        <ListView.InfoItem key={`${plan.id}-migrated`} style={{ paddingRight: 40 }}>
-                          <ListView.Icon type="pf" size="lg" name="screen" />&nbsp;<strong>{succeedCount}</strong>{' '}
-                          {__('of')} &nbsp;<strong>{Object.keys(tasks).length} </strong>
-                          {__('VMs successfully migrated.')}
-                        </ListView.InfoItem>,
-                        <ListView.InfoItem key={`${plan.id}-infraMappingName`}>
-                          {plan.infraMappingName}
-                        </ListView.InfoItem>,
-                        <ListView.InfoItem key={`${plan.id}-elapsed`}>
-                          <ListView.Icon type="fa" size="lg" name="clock-o" />
-                          {elapsedTime}
-                        </ListView.InfoItem>
-                      ]}
-                      actions={
-                        !archived && (
-                          <React.Fragment>
-                            {failed && (
+                    const archiveMigrationWarningText = (
+                      <React.Fragment>
+                        <p>
+                          {__('Are you sure you want to archive migration plan ')}
+                          <strong>{plan.name}</strong>?
+                        </p>
+                        {failed && (
+                          <p>
+                            {__('This plan includes VMs that failed to migrate. If you archive the plan, you will not be able to retry the failed migrations.') // prettier-ignore
+                            }
+                          </p>
+                        )}
+                      </React.Fragment>
+                    );
+
+                    const confirmModalBaseProps = {
+                      title: __('Archive Migration Plan'),
+                      body: archiveMigrationWarningText,
+                      icon: failed && <Icon className="confirm-warning-icon" type="pf" name="warning-triangle-o" />,
+                      confirmButtonLabel: __('Archive')
+                    };
+
+                    const onConfirm = () => {
+                      showConfirmModalAction({
+                        ...confirmModalBaseProps,
+                        disableCancelButton: true,
+                        disableConfirmButton: true
+                      });
+                      archiveTransformationPlanAction(archiveTransformationPlanUrl, plan.id)
+                        .then(() => {
+                          addNotificationAction({
+                            message: sprintf(__('%s successfully archived'), plan.name),
+                            notificationType: 'success',
+                            persistent: false
+                          });
+
+                          return fetchTransformationPlansAction({
+                            url: fetchTransformationPlansUrl,
+                            archived: false
+                          });
+                        })
+                        .then(() => {
+                          hideConfirmModalAction();
+                        });
+                    };
+
+                    const confirmModalOptions = {
+                      ...confirmModalBaseProps,
+                      onConfirm
+                    };
+
+                    return (
+                      <ListView.Item
+                        stacked
+                        className="plans-complete-list__list-item"
+                        onClick={e => {
+                          e.stopPropagation();
+
+                          redirectTo(`/migration/plan/${plan.id}`);
+                        }}
+                        key={plan.id}
+                        leftContent={
+                          archived ? (
+                            <ListView.Icon
+                              type="fa"
+                              name="archive"
+                              size="md"
+                              style={{
+                                width: 'inherit',
+                                backgroundColor: 'transparent',
+                                border: 'none'
+                              }}
+                            />
+                          ) : (
+                            <ListView.Icon
+                              type="pf"
+                              name={failed ? 'error-circle-o' : 'ok'}
+                              size="md"
+                              style={{
+                                width: 'inherit',
+                                backgroundColor: 'transparent'
+                              }}
+                            />
+                          )
+                        }
+                        heading={plan.name}
+                        description={plan.description}
+                        additionalInfo={[
+                          <ListView.InfoItem key={`${plan.id}-migrated`} style={{ paddingRight: 40 }}>
+                            <ListView.Icon type="pf" size="lg" name="screen" />&nbsp;<strong>{succeedCount}</strong>{' '}
+                            {__('of')} &nbsp;<strong>{Object.keys(tasks).length} </strong>
+                            {__('VMs successfully migrated.')}
+                          </ListView.InfoItem>,
+                          <ListView.InfoItem key={`${plan.id}-infraMappingName`}>
+                            {plan.infraMappingName}
+                          </ListView.InfoItem>,
+                          <ListView.InfoItem key={`${plan.id}-elapsed`}>
+                            <ListView.Icon type="fa" size="lg" name="clock-o" />
+                            {elapsedTime}
+                          </ListView.InfoItem>,
+                          migrationScheduled &&
+                            !staleMigrationSchedule && (
+                              <ListView.InfoItem key={plan.id + 1} style={{ textAlign: 'left' }}>
+                                <Icon type="fa" name="clock-o" />
+                                {__(`Migration scheduled`)}
+                                <br />
+                                {formatDateTime(migrationScheduled)}
+                              </ListView.InfoItem>
+                            )
+                        ]}
+                        actions={
+                          !archived && (
+                            <React.Fragment>
+                              {failed && (
+                                <React.Fragment>
+                                  <ScheduleMigrationButton
+                                    showConfirmModalAction={showConfirmModalAction}
+                                    hideConfirmModalAction={hideConfirmModalAction}
+                                    loading={loading}
+                                    toggleScheduleMigrationModal={toggleScheduleMigrationModal}
+                                    scheduleMigration={scheduleMigration}
+                                    fetchTransformationPlansAction={fetchTransformationPlansAction}
+                                    fetchTransformationPlansUrl={fetchTransformationPlansUrl}
+                                    plan={plan}
+                                  />
+                                  <Button
+                                    onClick={e => {
+                                      e.stopPropagation();
+                                      retryClick(plan.href, plan.id);
+                                    }}
+                                    disabled={loading === plan.href}
+                                  >
+                                    {__('Retry')}
+                                  </Button>
+                                </React.Fragment>
+                              )}
                               <Button
                                 onClick={e => {
                                   e.stopPropagation();
-                                  retryClick(plan.href, plan.id);
+                                  showConfirmModalAction(confirmModalOptions);
                                 }}
-                                disabled={loading === plan.href}
                               >
-                                {__('Retry')}
+                                {__('Archive')}
                               </Button>
-                            )}
-                            <Button
-                              onClick={e => {
-                                e.stopPropagation();
-                                showConfirmModalAction(confirmModalOptions);
-                              }}
-                            >
-                              {__('Archive')}
-                            </Button>
-                          </React.Fragment>
-                        )
-                      }
-                    />
-                  );
-                })}
-              </ListView>
-            </React.Fragment>
-          ) : (
-            <OverviewEmptyState
-              title={archived ? __('No Archived Migration Plans') : __('No Completed Migration Plans')}
-              iconType="pf"
-              iconName="info"
-              description={
-                <span>
-                  {archived
-                    ? __('There are no exisitng migration plans in an Archived state.')
-                    : __('There are no existing migration plans in a Completed state.')}
-                  <br /> {__('Make a selection in the dropdown to view plans in other states.')}
-                </span>
-              }
-            />
-          )}
-        </Spinner>
-      </Grid.Col>
+                            </React.Fragment>
+                          )
+                        }
+                      />
+                    );
+                  })}
+                </ListView>
+              </React.Fragment>
+            ) : (
+              <OverviewEmptyState
+                title={archived ? __('No Archived Migration Plans') : __('No Completed Migration Plans')}
+                iconType="pf"
+                iconName="info"
+                description={
+                  <span>
+                    {archived
+                      ? __('There are no exisitng migration plans in an Archived state.')
+                      : __('There are no existing migration plans in a Completed state.')}
+                    <br /> {__('Make a selection in the dropdown to view plans in other states.')}
+                  </span>
+                }
+              />
+            )}
+          </Spinner>
+        </Grid.Col>
+        <ScheduleMigrationModal
+          toggleScheduleMigrationModal={toggleScheduleMigrationModal}
+          scheduleMigrationModal={scheduleMigrationModal}
+          scheduleMigrationPlan={scheduleMigrationPlan}
+          scheduleMigration={scheduleMigration}
+          fetchTransformationPlansAction={fetchTransformationPlansAction}
+          fetchTransformationPlansUrl={fetchTransformationPlansUrl}
+        />
+      </React.Fragment>
     );
   }
 }
@@ -283,7 +326,11 @@ MigrationsCompletedList.propTypes = {
   archiveTransformationPlanUrl: PropTypes.string,
   fetchTransformationPlansAction: PropTypes.func,
   fetchTransformationPlansUrl: PropTypes.string,
-  addNotificationAction: PropTypes.func
+  addNotificationAction: PropTypes.func,
+  toggleScheduleMigrationModal: PropTypes.func,
+  scheduleMigrationModal: PropTypes.bool,
+  scheduleMigrationPlan: PropTypes.object,
+  scheduleMigration: PropTypes.func
 };
 MigrationsCompletedList.defaultProps = {
   finishedTransformationPlans: [],

--- a/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/MigrationsNotStartedList.js
@@ -7,6 +7,7 @@ import ScheduleMigrationModal from '../ScheduleMigrationModal/ScheduleMigrationM
 import { formatDateTime } from '../../../../../../components/dates/MomentDate';
 import { MIGRATIONS_NOT_STARTED_SORT_FIELDS } from './MigrationsConstants';
 import sortFilter from '../../../Plan/components/sortFilter';
+import ScheduleMigrationButton from './ScheduleMigrationButton';
 
 class MigrationsNotStartedList extends React.Component {
   state = {
@@ -51,7 +52,7 @@ class MigrationsNotStartedList extends React.Component {
       hideConfirmModalAction,
       toggleScheduleMigrationModal,
       scheduleMigrationModal,
-      scheduleMigrationPlanId,
+      scheduleMigrationPlan,
       scheduleMigration,
       fetchTransformationPlansAction,
       fetchTransformationPlansUrl
@@ -84,43 +85,6 @@ class MigrationsNotStartedList extends React.Component {
                   {sortedMigrations.map(plan => {
                     const migrationScheduled = plan.schedules && plan.schedules[0].run_at.start_time;
 
-                    const confirmationWarningText = (
-                      <React.Fragment>
-                        <p>
-                          {sprintf(
-                            __('Are you sure you want to unschedule plan %s  targted to run on %s ?'),
-                            plan.name,
-                            formatDateTime(migrationScheduled)
-                          )}
-                        </p>
-                      </React.Fragment>
-                    );
-
-                    const confirmModalProps = {
-                      title: __('Unschedule Migration Plan'),
-                      body: confirmationWarningText,
-                      icon: <Icon className="confirm-warning-icon" type="pf" name="warning-triangle-o" />,
-                      confirmButtonLabel: __('Unschedule')
-                    };
-
-                    const onConfirm = () => {
-                      scheduleMigration({
-                        planId: plan.id,
-                        scheduleId: plan.schedules[0].id
-                      }).then(() => {
-                        fetchTransformationPlansAction({
-                          url: fetchTransformationPlansUrl,
-                          archived: false
-                        });
-                      });
-                      hideConfirmModalAction();
-                    };
-
-                    const confirmModalOptions = {
-                      ...confirmModalProps,
-                      onConfirm
-                    };
-
                     return (
                       <ListView.Item
                         stacked
@@ -130,30 +94,16 @@ class MigrationsNotStartedList extends React.Component {
                         }}
                         actions={
                           <div>
-                            {!migrationScheduled && (
-                              <Button
-                                id={`schedule_${plan.id}`}
-                                onClick={e => {
-                                  e.stopPropagation();
-                                  toggleScheduleMigrationModal({ planId: plan.id });
-                                }}
-                                disabled={loading === plan.href || plan.schedule_type}
-                              >
-                                {__('Schedule')}
-                              </Button>
-                            )}
-                            {migrationScheduled && (
-                              <Button
-                                id={`unschedule_${plan.id}`}
-                                onClick={e => {
-                                  e.stopPropagation();
-                                  showConfirmModalAction(confirmModalOptions);
-                                }}
-                                disabled={loading === plan.href}
-                              >
-                                {__('Unschedule')}
-                              </Button>
-                            )}
+                            <ScheduleMigrationButton
+                              showConfirmModalAction={showConfirmModalAction}
+                              hideConfirmModalAction={hideConfirmModalAction}
+                              loading={loading}
+                              toggleScheduleMigrationModal={toggleScheduleMigrationModal}
+                              scheduleMigration={scheduleMigration}
+                              fetchTransformationPlansAction={fetchTransformationPlansAction}
+                              fetchTransformationPlansUrl={fetchTransformationPlansUrl}
+                              plan={plan}
+                            />
                             <Button
                               id={`migrate_${plan.id}`}
                               onClick={e => {
@@ -214,7 +164,7 @@ class MigrationsNotStartedList extends React.Component {
         <ScheduleMigrationModal
           toggleScheduleMigrationModal={toggleScheduleMigrationModal}
           scheduleMigrationModal={scheduleMigrationModal}
-          scheduleMigrationPlanId={scheduleMigrationPlanId}
+          scheduleMigrationPlan={scheduleMigrationPlan}
           scheduleMigration={scheduleMigration}
           fetchTransformationPlansAction={fetchTransformationPlansAction}
           fetchTransformationPlansUrl={fetchTransformationPlansUrl}
@@ -233,7 +183,7 @@ MigrationsNotStartedList.propTypes = {
   redirectTo: PropTypes.func,
   toggleScheduleMigrationModal: PropTypes.func,
   scheduleMigrationModal: PropTypes.bool,
-  scheduleMigrationPlanId: PropTypes.string,
+  scheduleMigrationPlan: PropTypes.object,
   scheduleMigration: PropTypes.func,
   fetchTransformationPlansAction: PropTypes.func,
   fetchTransformationPlansUrl: PropTypes.string

--- a/app/javascript/react/screens/App/Overview/components/Migrations/ScheduleMigrationButton.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/ScheduleMigrationButton.js
@@ -1,0 +1,94 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button, Icon } from 'patternfly-react';
+import { formatDateTime } from '../../../../../../components/dates/MomentDate';
+
+const ScheduleMigrationButton = ({
+  showConfirmModalAction,
+  hideConfirmModalAction,
+  loading,
+  toggleScheduleMigrationModal,
+  scheduleMigration,
+  fetchTransformationPlansAction,
+  fetchTransformationPlansUrl,
+  plan
+}) => {
+  const migrationScheduled = plan.schedules && plan.schedules[0].run_at.start_time;
+  const staleMigrationSchedule = (new Date(migrationScheduled).getTime() || 0) < Date.now();
+  const confirmationWarningText = (
+    <React.Fragment>
+      <p>
+        {sprintf(
+          __('Are you sure you want to unschedule plan %s  targted to run on %s ?'),
+          plan.name,
+          formatDateTime(migrationScheduled)
+        )}
+      </p>
+    </React.Fragment>
+  );
+
+  const confirmModalProps = {
+    title: __('Unschedule Migration Plan'),
+    body: confirmationWarningText,
+    icon: <Icon className="confirm-warning-icon" type="pf" name="warning-triangle-o" />,
+    confirmButtonLabel: __('Unschedule')
+  };
+
+  const onConfirm = () => {
+    scheduleMigration({
+      plan
+    }).then(() => {
+      fetchTransformationPlansAction({
+        url: fetchTransformationPlansUrl,
+        archived: false
+      });
+    });
+    hideConfirmModalAction();
+  };
+
+  return (
+    <React.Fragment>
+      {staleMigrationSchedule && (
+        <Button
+          id={`schedule_${plan.id}`}
+          onClick={e => {
+            e.stopPropagation();
+            toggleScheduleMigrationModal({ plan });
+          }}
+          disabled={loading === plan.href || plan.schedule_type}
+        >
+          {__('Schedule')}
+        </Button>
+      )}
+      {!staleMigrationSchedule && (
+        <Button
+          id={`unschedule_${plan.id}`}
+          onClick={e => {
+            e.stopPropagation();
+
+            showConfirmModalAction({
+              ...confirmModalProps,
+              onConfirm
+            });
+          }}
+          disabled={loading === plan.href}
+        >
+          {__('Unschedule')}
+        </Button>
+      )}
+    </React.Fragment>
+  );
+};
+
+ScheduleMigrationButton.propTypes = {
+  showConfirmModalAction: PropTypes.func,
+  hideConfirmModalAction: PropTypes.func,
+  loading: PropTypes.string,
+  toggleScheduleMigrationModal: PropTypes.func,
+  scheduleMigration: PropTypes.func,
+  fetchTransformationPlansAction: PropTypes.func,
+  fetchTransformationPlansUrl: PropTypes.string,
+  plan: PropTypes.object
+};
+
+export default ScheduleMigrationButton;

--- a/app/javascript/react/screens/App/Overview/components/Migrations/__test__/MigrationsCompletedList.test.js
+++ b/app/javascript/react/screens/App/Overview/components/Migrations/__test__/MigrationsCompletedList.test.js
@@ -59,7 +59,7 @@ describe('when displaying active (not archived) migration plans', () => {
 
   test('clicking the archive button launches the confirmation modal', () => {
     wrapper.find('ListViewItem').forEach(item => {
-      const archiveButton = item.find('Button').filterWhere(button => button.text() === 'Archive');
+      const archiveButton = item.find('a').filterWhere(link => link.text() === 'Archive');
 
       archiveButton.simulate('click');
 

--- a/app/javascript/react/screens/App/Overview/components/ScheduleMigrationModal/ScheduleMigrationModal.js
+++ b/app/javascript/react/screens/App/Overview/components/ScheduleMigrationModal/ScheduleMigrationModal.js
@@ -12,7 +12,7 @@ class ScheduleMigrationModal extends React.Component {
     const {
       toggleScheduleMigrationModal,
       scheduleMigrationModal,
-      scheduleMigrationPlanId,
+      scheduleMigrationPlan,
       scheduleMigration,
       fetchTransformationPlansAction,
       fetchTransformationPlansUrl
@@ -45,7 +45,7 @@ class ScheduleMigrationModal extends React.Component {
             disabled={!this.state.dateTimeInput}
             onClick={() => {
               scheduleMigration({
-                planId: scheduleMigrationPlanId,
+                plan: scheduleMigrationPlan,
                 scheduleTime: moment(this.state.dateTimeInput).format('YYYYMMDDTHHmm')
               }).then(() => {
                 fetchTransformationPlansAction({
@@ -66,7 +66,7 @@ class ScheduleMigrationModal extends React.Component {
 ScheduleMigrationModal.propTypes = {
   scheduleMigrationModal: PropTypes.bool,
   toggleScheduleMigrationModal: PropTypes.func,
-  scheduleMigrationPlanId: PropTypes.string,
+  scheduleMigrationPlan: PropTypes.object,
   scheduleMigration: PropTypes.func,
   fetchTransformationPlansAction: PropTypes.func,
   fetchTransformationPlansUrl: PropTypes.string


### PR DESCRIPTION
Fixes #515
### What we look like
<img width="1161" alt="screen shot 2018-07-27 at 10 41 41 am" src="https://user-images.githubusercontent.com/6640236/43327585-cbe9b166-9189-11e8-825c-d880defc01ac.png">

OK OK so there's an issue with the using the kebab [(described here)](https://github.com/ManageIQ/miq_v2v_ui_plugin/pull/514#issuecomment-408263817) so we're using buttons for now. We now hide "stale migrations" from the completed list, those migrations that happened in the past, and allow the user to schedule anew **but** there's an issue with the api serializing the keys (?) or something like that, so rescheduling an already failed migration doesn't so much work @bdunne is looking into da issue... 

### ~its a long video, but worth a watch!~ Its now an old video, but still worth watching
![asdfassssss](https://user-images.githubusercontent.com/6640236/43222631-a4292718-901e-11e8-9161-eefde1634c67.gif)
~Edit: if this seems clunky, having to unschedule to re schedule, s' something that can be improved upon, but I don't want to make any promises before that it could be done by friday, so here seems like a good stopping spot... 🤞~