### PR TITLE
[#528] Do not overwrite selected target provider

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardGeneralStep/MappingWizardGeneralStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardGeneralStep/MappingWizardGeneralStep.js
@@ -52,7 +52,7 @@ const MappingWizardGeneralStep = props => {
         options={V2V_TARGET_PROVIDERS}
         option_key="id"
         option_value="name"
-        pre_selected_value={V2V_TARGET_PROVIDERS[0].id}
+        pre_selected_value={props.targetProvider || V2V_TARGET_PROVIDERS[0].id}
         labelWidth={2}
         controlWidth={9}
         inline_label
@@ -69,7 +69,7 @@ MappingWizardGeneralStep.propTypes = {
 };
 
 MappingWizardGeneralStep.defaultProps = {
-  targetProvider: 'rhevm',
+  targetProvider: '',
   dispatch: noop
 };
 


### PR DESCRIPTION
We only want to set the default target provider when first opening the
wizard.  This fixes a bug where revisiting the General Step always reset
the target provider to rhevm

# Notes
To test, comment [this line](https://github.com/ManageIQ/miq_v2v_ui_plugin/pull/510/files#diff-f62459b84c7fdf0c959a7f02e7f2c2efR60) to make the dropdown select visible, and inspect the value for `form.mappingWizardGeneralStep.values.targetProvider` in redux