### PR TITLE
[#507] OSP - Infra Mapping Wizard Step 3

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/MappingWizardConstants.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/MappingWizardConstants.js
@@ -8,3 +8,5 @@ export const V2V_TARGET_PROVIDERS = [
   { name: __('Red Hat Virtualization'), id: 'rhevm' },
   { name: __('Red Hat OpenStack Platform'), id: 'openstack' }
 ];
+
+export const V2V_TARGET_PROVIDER_STORAGE_KEYS = { rhevm: 'storages', openstack: 'cloud_volumes' };

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStep.js
@@ -101,7 +101,7 @@ class MappingWizardDatastoresStep extends React.Component {
       <div>
         <Field
           name="cluster_select"
-          label={__('Map source datastores to target datastores for cluster')}
+          label={__('Select a source cluster whose datastores you want to map')}
           data_live_search="true"
           component={BootstrapSelect}
           options={clusterOptions}

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStep.js
@@ -88,7 +88,8 @@ class MappingWizardDatastoresStep extends React.Component {
       sourceDatastores,
       targetDatastores,
       form,
-      showAlertAction
+      showAlertAction,
+      targetProvider
     } = this.props;
 
     const { selectedCluster, selectedClusterMapping } = this.state;
@@ -127,6 +128,7 @@ class MappingWizardDatastoresStep extends React.Component {
           isFetchingTargetDatastores={isFetchingTargetDatastores}
           validate={length({ min: 1 })}
           showAlertAction={showAlertAction}
+          targetProvider={targetProvider}
         />
       </div>
     );

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepActions.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepActions.js
@@ -5,6 +5,7 @@ import {
   FETCH_V2V_TARGET_DATASTORES,
   QUERY_ATTRIBUTES
 } from './MappingWizardDatastoresStepConstants';
+import { V2V_TARGET_PROVIDER_STORAGE_KEYS } from '../../MappingWizardConstants';
 
 const _filterSourceDatastores = response => {
   const { data } = response;
@@ -44,10 +45,11 @@ export const fetchSourceDatastoresAction = (url, id) => {
   return _getSourceDatastoresActionCreator(uri.toString());
 };
 
-const _filterTargetDatastores = response => {
+const _filterTargetDatastores = (response, targetProvider) => {
   const { data } = response;
-  if (data.storages) {
-    const targetDatastores = data.storages.map(storage => ({
+
+  if (data[V2V_TARGET_PROVIDER_STORAGE_KEYS[targetProvider]]) {
+    const targetDatastores = data[V2V_TARGET_PROVIDER_STORAGE_KEYS[targetProvider]].map(storage => ({
       ...storage,
       providerName: data.ext_management_system.name
     }));
@@ -60,13 +62,13 @@ const _filterTargetDatastores = response => {
   };
 };
 
-const _getTargetDatastoresActionCreator = url => dispatch =>
+const _getTargetDatastoresActionCreator = (url, targetProvider) => dispatch =>
   dispatch({
     type: FETCH_V2V_TARGET_DATASTORES,
     payload: new Promise((resolve, reject) => {
       API.get(url)
         .then(response => {
-          resolve(_filterTargetDatastores(response));
+          resolve(_filterTargetDatastores(response, targetProvider));
         })
         .catch(e => reject(e));
     })
@@ -77,5 +79,5 @@ export const fetchTargetDatastoresAction = (url, id, targetProvider) => {
   // creates url like: http://localhost:3000/api/clusters/1?attributes=storages
   uri.addSearch({ attributes: QUERY_ATTRIBUTES[targetProvider] });
 
-  return _getTargetDatastoresActionCreator(uri.toString());
+  return _getTargetDatastoresActionCreator(uri.toString(), targetProvider);
 };

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepActions.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/MappingWizardDatastoresStepActions.js
@@ -12,7 +12,8 @@ const _filterSourceDatastores = response => {
   if (data.storages) {
     const sourceDatastores = data.storages.map(storage => ({
       ...storage,
-      providerName: data.ext_management_system.name
+      providerName: data.ext_management_system.name,
+      datacenterName: data.v_parent_datacenter
     }));
     return {
       sourceDatastores
@@ -40,7 +41,7 @@ const _getSourceDatastoresActionCreator = url => dispatch =>
 export const fetchSourceDatastoresAction = (url, id) => {
   const uri = new URI(`${url}/${id}`);
   // creates url like: http://localhost:3000/api/clusters/1?attributes=storages
-  uri.addSearch({ attributes: QUERY_ATTRIBUTES.source });
+  uri.addSearch({ attributes: `${QUERY_ATTRIBUTES.source},v_parent_datacenter` });
 
   return _getSourceDatastoresActionCreator(uri.toString());
 };

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/DatastoresStepForm.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/DatastoresStepForm.js
@@ -10,6 +10,7 @@ import MappingWizardTreeView from '../../../MappingWizardTreeView/MappingWizardT
 
 import { sourceDatastoreFilter } from '../../MappingWizardDatastoresStepSelectors';
 import { targetDatastoreTreeViewInfo, sourceDatastoreInfo, targetDatastoreInfo, updateMappings } from './helpers';
+import { multiProviderTargetLabel } from '../../../helpers';
 
 class DatastoresStepForm extends React.Component {
   state = {
@@ -248,7 +249,8 @@ class DatastoresStepForm extends React.Component {
       isFetchingSourceDatastores,
       isFetchingTargetDatastores,
       input,
-      selectedCluster
+      selectedCluster,
+      targetProvider
     } = this.props;
     const { selectedSourceDatastores, selectedTargetDatastore, selectedNode } = this.state;
 
@@ -297,7 +299,7 @@ class DatastoresStepForm extends React.Component {
           </DualPaneMapperList>
           <DualPaneMapperList
             id="target_datastores"
-            listTitle={__('Target Datastores')}
+            listTitle={multiProviderTargetLabel(targetProvider, 'storage')}
             loading={isFetchingTargetDatastores}
           >
             {targetDatastores &&
@@ -334,5 +336,6 @@ DatastoresStepForm.propTypes = {
   sourceDatastores: PropTypes.array,
   targetDatastores: PropTypes.array,
   isFetchingSourceDatastores: PropTypes.bool,
-  isFetchingTargetDatastores: PropTypes.bool
+  isFetchingTargetDatastores: PropTypes.bool,
+  targetProvider: PropTypes.string
 };

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/DatastoresStepForm.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/DatastoresStepForm.js
@@ -269,7 +269,7 @@ class DatastoresStepForm extends React.Component {
       <div className={classes}>
         <p style={{ marginLeft: -40 }}>
           {__(
-            'Select source cluster(s) and a target cluster and click Add Mapping to add the mapping. Multiple mappings can be added.') // prettier-ignore
+            'Select source datastore(s) and a target datastore and click Add Mapping to add the mapping. Multiple mappings can be added.') // prettier-ignore
           }
         </p>
         <DualPaneMapper

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/DatastoresStepForm.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/DatastoresStepForm.js
@@ -265,13 +265,18 @@ class DatastoresStepForm extends React.Component {
 
     return (
       <div className={classes}>
+        <p style={{ marginLeft: -40 }}>
+          {__(
+            'Select source cluster(s) and a target cluster and click Add Mapping to add the mapping. Multiple mappings can be added.') // prettier-ignore
+          }
+        </p>
         <DualPaneMapper
           handleButtonClick={this.addDatastoreMapping}
           validMapping={!(selectedTargetDatastore && (selectedSourceDatastores && selectedSourceDatastores.length > 0))}
         >
           <DualPaneMapperList
             id="source_datastores"
-            listTitle={__('Source Datastores')}
+            listTitle={__('Source Provider \\ Datacenter \\ Datastore')}
             loading={isFetchingSourceDatastores}
             counter={counter}
           >

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/helpers.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardDatastoresStep/components/DatastoresStepForm/helpers.js
@@ -20,7 +20,7 @@ export const targetDatastoreAvailableSpace = (targetDatastore, datastoresStepMap
 };
 
 export const sourceDatastoreInfo = sourceDatastore =>
-  sprintf(__('%s \\ %s'), sourceDatastore.providerName, sourceDatastore.name);
+  sprintf(__('%s \\ %s \\ %s'), sourceDatastore.providerName, sourceDatastore.datacenterName, sourceDatastore.name);
 
 export const targetDatastoreInfo = (targetDatastore, datastoresStepMappings) =>
   sprintf(__('%s \\ %s'), targetDatastore.providerName, targetDatastore.name);

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/helpers.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/helpers.js
@@ -28,6 +28,8 @@ export const multiProviderTargetLabel = (providerType, wizardStep) => {
       switch (wizardStep) {
         case 'cluster':
           return __('Target Provider \\ Project');
+        case 'storage':
+          return __('Target Provider \\ Cloud Volume');
         case 'network':
           return __('Target Project \\ Network');
         default:
@@ -37,6 +39,8 @@ export const multiProviderTargetLabel = (providerType, wizardStep) => {
       switch (wizardStep) {
         case 'cluster':
           return __('Target Provider \\ Datacenter \\ Cluster');
+        case 'storage':
+          return __('Target Datastores');
         case 'network':
           return __('Target Networks');
         default:


### PR DESCRIPTION
# Notes
1.  Use one of the test dbs (e.g. 6_0_dc_MBU_demo_..._backup)
2.  Use the `openshift_demo` target project in the Compute Step to see `cloud_volumes`.  Not all the `cloud_tenants` seem to have associated storages
3.  OSP API details are not finalized yet, so for now, we will fetch `cloud_volumes` and display
    ```
    Provider Name / Cloud Volume Name
    ```
4.  Remember to comment out [this prop](https://github.com/ManageIQ/miq_v2v_ui_plugin/blob/master/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardGeneralStep/MappingWizardGeneralStep.js#L60) to be able to switch between `RHV` and `OpenStack` target providers

# Screens
<img width="1920" alt="fullscreen_8_6_18__4_24_pm" src="https://user-images.githubusercontent.com/15141412/43739210-3feb20f0-9995-11e8-934d-ed9d75115ee8.png">
