### PR TITLE
Fix PropType warning around warningMessage for target clusters

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm/ClustersStepForm.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/components/ClustersStepForm/ClustersStepForm.js
@@ -181,7 +181,7 @@ class ClustersStepForm extends React.Component {
                     selected={selectedTargetCluster && selectedTargetCluster.id === item.id}
                     handleClick={this.selectTargetCluster}
                     handleKeyPress={this.selectTargetCluster}
-                    warningMessage={showWarning && targetConversionHostWarning}
+                    warningMessage={showWarning ? targetConversionHostWarning : ''}
                   />
                 );
               })}


### PR DESCRIPTION
Whoops. Found this while testing a bit more thoroughly to create the screen recording for #526 . This is already pushed to the backport PR #539, but it needs to be merged to master too.