### PR TITLE
[#466] Fix the Plan Wizard Results Step API Error Handling

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardResultsStep/PlanWizardResultsStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardResultsStep/PlanWizardResultsStep.js
@@ -26,9 +26,10 @@ class PlanWizardResultsStep extends React.Component {
       isRejectedPostingPlans,
       migrationPlansResult,
       migrationRequestsResult,
-      errorPostingPlans, // eslint-disable-line no-unused-vars
+      errorPostingPlans,
       plansBody,
-      planSchedule
+      planSchedule,
+      hidePlanWizardAction
     } = this.props;
 
     if (isPostingPlans) {
@@ -42,17 +43,17 @@ class PlanWizardResultsStep extends React.Component {
         </div>
       );
     } else if (isRejectedPostingPlans) {
+      const errorData = errorPostingPlans && errorPostingPlans.data;
+      const errorMessage = errorData && errorData.error && errorData.error.message;
       return (
         <div className="wizard-pf-complete blank-slate-pf">
           <div className="wizard-pf-success-icon">
             <span className="pficon pficon-error-circle-o" />
           </div>
           <h3 className="blank-slate-pf-main-action">{__('Error Creating Migration Plans')}</h3>
-          <p className="blank-slate-pf-secondary-action">
-            {__("We're sorry, something went wrong. Please try again.")}
-          </p>
-          <button type="button" className="btn btn-lg btn-primary">
-            {__('Retry')}
+          <p className="blank-slate-pf-secondary-action">{errorMessage}</p>
+          <button type="button" className="btn btn-lg btn-primary" onClick={hidePlanWizardAction}>
+            {__('Close')}
           </button>
         </div>
       );
@@ -77,7 +78,8 @@ PlanWizardResultsStep.propTypes = {
   isRejectedPostingPlans: PropTypes.bool,
   errorPostingPlans: PropTypes.object,
   migrationPlansResult: PropTypes.object,
-  migrationRequestsResult: PropTypes.object
+  migrationRequestsResult: PropTypes.object,
+  hidePlanWizardAction: PropTypes.func
 };
 PlanWizardResultsStep.defaultProps = {
   postPlansUrl: '',
@@ -88,6 +90,7 @@ PlanWizardResultsStep.defaultProps = {
   isRejectedPostingPlans: false,
   errorPostingPlans: null,
   migrationPlansResult: null,
-  migrationRequestsResult: null
+  migrationRequestsResult: null,
+  hidePlanWizardAction: noop
 };
 export default PlanWizardResultsStep;

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardResultsStep/PlanWizardResultsStepActions.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardResultsStep/PlanWizardResultsStepActions.js
@@ -1,6 +1,8 @@
 import API from '../../../../../../../../common/API';
 import { POST_V2V_MIGRATION_PLANS, POST_V2V_MIGRATION_REQUESTS } from './PlanWizardResultsStepConstants';
 
+export { hidePlanWizardAction } from '../../PlanWizardActions';
+
 const postMigrationRequestsAction = (response, dispatch) => {
   dispatch({
     type: POST_V2V_MIGRATION_REQUESTS,


### PR DESCRIPTION
Fixes #466

This PR removes the "We're sorry, something went wrong. Please try again" messaging if there is an API error at the end of the Plan Wizard, and instead shows the error message sent by the API. It also replaces the non-functional Retry button with a functional Close button.

![screenshot 2018-08-06 13 26 11](https://user-images.githubusercontent.com/811963/43731444-877a8762-997c-11e8-944a-582b8bf7065f.png)

In order to test this PR, you can cherry-pick the following commit on top of this branch, which will defeat the error handling in the General step of the wizard, which allows you to try to create a plan with the same name as an existing plan, which will cause an API error.

Commit to cherry-pick for forcing errors: https://github.com/mturley/miq_v2v_ui_plugin/commit/a6ff3671ecc3c3fb83b83763733444514e5b18be
