### PR TITLE
[#548] Few tweaks around cancelling tasks to reflect the status accurately

### DIFF
--- a/app/javascript/react/screens/App/Plan/PlanActions.js
+++ b/app/javascript/react/screens/App/Plan/PlanActions.js
@@ -252,7 +252,7 @@ export const cancelPlanRequestTasksAction = (url, tasks) => dispatch => {
         .then(response => {
           resolve(response);
 
-          const cancelSuccessMsg = __('Migration canceled successfully for VMs: ');
+          const cancelSuccessMsg = __('Migration cancel request submitted for VMs: ');
           const vmNames = tasks.map(task => task.vmName).join(', ');
           const cancelSuccessMsgWithVMNames = `${cancelSuccessMsg} ${vmNames}`;
 

--- a/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
+++ b/app/javascript/react/screens/App/Plan/components/PlanRequestDetailList/PlanRequestDetailList.js
@@ -469,7 +469,7 @@ class PlanRequestDetailList extends React.Component {
                 taskCancelling = true;
               }
               if (taskCancelled || taskCancelling) {
-                taskMessage = `${__('Canceled Migration')}: ${taskMessage}`;
+                taskMessage = `${task.message}: ${__('Cancelling migration')}`;
               }
               let leftContent;
               if (task.message === 'Pending') {
@@ -481,7 +481,8 @@ class PlanRequestDetailList extends React.Component {
                     style={{ width: 'inherit', backgroundColor: 'transparent' }}
                   />
                 );
-              } else if (taskCancelling || taskCancelled) {
+              } else if (taskCancelled && task.completed) {
+                taskMessage = `${task.message}: ${__('Migration cancelled')}`;
                 leftContent = (
                   <ListView.Icon
                     type="fa"
@@ -508,7 +509,7 @@ class PlanRequestDetailList extends React.Component {
                     style={{ width: 'inherit', backgroundColor: 'transparent' }}
                   />
                 );
-              } else if (!taskCancelling && !taskCancelled) {
+              } else {
                 leftContent = <Spinner loading />;
               }
               const label = sprintf(__('%s of %s Migrated'), task.diskSpaceCompletedGb, task.totalDiskSpaceGb);


### PR DESCRIPTION
Fixes #548

Leveraged existing variables `taskCancelling` and `taskCancelled` to do the tweaking and appropriately reflect the correct status of Cancel.