### PR TITLE
Update createTransformationMappings helper

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/helpers.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/helpers.js
@@ -4,14 +4,15 @@ export const createTransformationMappings = (
   mappingWizardDatastoresStep,
   mappingWizardNetworksStep
 ) => {
-  const clustersUrlRegEx = /\/api\/clusters\/\d{1,}/;
+  const sourceComputeUrlRegEx = /\/api\/clusters\/\d{1,}/;
+  const targetComputeUrlRegEx = /\/api\/clusters|cloud_tenants\/\d{1,}/;
   const clusterTransformationMappings = mappingWizardClustersStep.values.clusterMappings.reduce(
     (clusterTransformationsArray, targetClusterWithSourceClusters) => {
-      const destination = targetClusterWithSourceClusters.href.match(clustersUrlRegEx)[0];
+      const destination = targetClusterWithSourceClusters.href.match(targetComputeUrlRegEx)[0];
       const transformations = targetClusterWithSourceClusters.nodes.reduce(
         (clusterTransformations, sourceCluster) =>
           clusterTransformations.concat({
-            source: sourceCluster.href.match(clustersUrlRegEx)[0],
+            source: sourceCluster.href.match(sourceComputeUrlRegEx)[0],
             destination
           }),
         []
@@ -21,7 +22,8 @@ export const createTransformationMappings = (
     []
   );
 
-  const datastoresUrlRegEx = /\/api\/data_stores\/\d{1,}/;
+  const sourceStoragesUrlRegEx = /\/api\/data_stores\/\d{1,}/;
+  const targetStoragesUrlRegEx = /\/api\/data_stores|cloud_volumes\/\d{1,}/;
   const datastoreTransformationMappings = mappingWizardDatastoresStep.values.datastoresMappings.reduce(
     (datastoreTransformationsPerTargetCluster, targetClusterWithDatastoreMappings) => {
       const datastoreTransformationsForTargetCluster = targetClusterWithDatastoreMappings.nodes.reduce(
@@ -29,8 +31,8 @@ export const createTransformationMappings = (
           const datastoreTransformations = targetDatastoreWithSourceDatastores.nodes.reduce(
             (transformations, sourceDatastore) =>
               transformations.concat({
-                source: sourceDatastore.href.match(datastoresUrlRegEx)[0],
-                destination: targetDatastoreWithSourceDatastores.href.match(datastoresUrlRegEx)[0]
+                source: sourceDatastore.href.match(sourceStoragesUrlRegEx)[0],
+                destination: targetDatastoreWithSourceDatastores.href.match(targetStoragesUrlRegEx)[0]
               }),
             []
           );
@@ -43,7 +45,8 @@ export const createTransformationMappings = (
     []
   );
 
-  const networksUrlRegEx = /\/api\/lans\/\d{1,}/;
+  const sourceNetworksUrlRegEx = /\/api\/lans\/\d{1,}/;
+  const targetNetworksUrlRegEx = /\/api\/lans|cloud_networks\/\d{1,}/;
   const networkTransformationMappings = mappingWizardNetworksStep.values.networksMappings.reduce(
     (networkTransformationsPerTargetCluster, targetClusterWithNetworkMappings) => {
       const networkTransformationsForTargetCluster = targetClusterWithNetworkMappings.nodes.reduce(
@@ -51,8 +54,8 @@ export const createTransformationMappings = (
           const networkTransformations = targetNetworkWithSourceNetworks.nodes.reduce(
             (transformations, sourceNetwork) =>
               transformations.concat({
-                source: sourceNetwork.href.match(networksUrlRegEx)[0],
-                destination: targetNetworkWithSourceNetworks.href.match(networksUrlRegEx)[0]
+                source: sourceNetwork.href.match(sourceNetworksUrlRegEx)[0],
+                destination: targetNetworkWithSourceNetworks.href.match(targetNetworksUrlRegEx)[0]
               }),
             []
           );

--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/helpers.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/helpers.js
@@ -1,18 +1,18 @@
+export const mappingUrlRegex = /\/api\/\w{1,}\/\d{1,}/;
+
 export const createTransformationMappings = (
   mappingWizardGeneralStep,
   mappingWizardClustersStep,
   mappingWizardDatastoresStep,
   mappingWizardNetworksStep
 ) => {
-  const sourceComputeUrlRegEx = /\/api\/clusters\/\d{1,}/;
-  const targetComputeUrlRegEx = /\/api\/clusters|cloud_tenants\/\d{1,}/;
   const clusterTransformationMappings = mappingWizardClustersStep.values.clusterMappings.reduce(
     (clusterTransformationsArray, targetClusterWithSourceClusters) => {
-      const destination = targetClusterWithSourceClusters.href.match(targetComputeUrlRegEx)[0];
+      const destination = targetClusterWithSourceClusters.href.match(mappingUrlRegex)[0];
       const transformations = targetClusterWithSourceClusters.nodes.reduce(
         (clusterTransformations, sourceCluster) =>
           clusterTransformations.concat({
-            source: sourceCluster.href.match(sourceComputeUrlRegEx)[0],
+            source: sourceCluster.href.match(mappingUrlRegex)[0],
             destination
           }),
         []
@@ -22,8 +22,6 @@ export const createTransformationMappings = (
     []
   );
 
-  const sourceStoragesUrlRegEx = /\/api\/data_stores\/\d{1,}/;
-  const targetStoragesUrlRegEx = /\/api\/data_stores|cloud_volumes\/\d{1,}/;
   const datastoreTransformationMappings = mappingWizardDatastoresStep.values.datastoresMappings.reduce(
     (datastoreTransformationsPerTargetCluster, targetClusterWithDatastoreMappings) => {
       const datastoreTransformationsForTargetCluster = targetClusterWithDatastoreMappings.nodes.reduce(
@@ -31,8 +29,8 @@ export const createTransformationMappings = (
           const datastoreTransformations = targetDatastoreWithSourceDatastores.nodes.reduce(
             (transformations, sourceDatastore) =>
               transformations.concat({
-                source: sourceDatastore.href.match(sourceStoragesUrlRegEx)[0],
-                destination: targetDatastoreWithSourceDatastores.href.match(targetStoragesUrlRegEx)[0]
+                source: sourceDatastore.href.match(mappingUrlRegex)[0],
+                destination: targetDatastoreWithSourceDatastores.href.match(mappingUrlRegex)[0]
               }),
             []
           );
@@ -45,8 +43,6 @@ export const createTransformationMappings = (
     []
   );
 
-  const sourceNetworksUrlRegEx = /\/api\/lans\/\d{1,}/;
-  const targetNetworksUrlRegEx = /\/api\/lans|cloud_networks\/\d{1,}/;
   const networkTransformationMappings = mappingWizardNetworksStep.values.networksMappings.reduce(
     (networkTransformationsPerTargetCluster, targetClusterWithNetworkMappings) => {
       const networkTransformationsForTargetCluster = targetClusterWithNetworkMappings.nodes.reduce(
@@ -54,8 +50,8 @@ export const createTransformationMappings = (
           const networkTransformations = targetNetworkWithSourceNetworks.nodes.reduce(
             (transformations, sourceNetwork) =>
               transformations.concat({
-                source: sourceNetwork.href.match(sourceNetworksUrlRegEx)[0],
-                destination: targetNetworkWithSourceNetworks.href.match(targetNetworksUrlRegEx)[0]
+                source: sourceNetwork.href.match(mappingUrlRegex)[0],
+                destination: targetNetworkWithSourceNetworks.href.match(mappingUrlRegex)[0]
               }),
             []
           );


### PR DESCRIPTION
Update regexes to account for OSP mapping types.

# Notes
1.  Once #530 is merged, this is needed in order to create OSP specific transformation mappings
2.  The `Infrastructure Mappings` section in Overview will need to be updated for OSP mappings.

Addendum to issues #505, #506, #507, #508 

# OSP Transformation Mapping
<img width="1440" alt="fullscreen_8_8_18__12_53_pm" src="https://user-images.githubusercontent.com/15141412/43852161-86e9cd00-9b0a-11e8-938a-10cf5f0b6b42.png">
