### PR TITLE
Adds plan transmutation to archived plans, creates inframappingname key

### DIFF
--- a/app/javascript/react/screens/App/Overview/helpers.js
+++ b/app/javascript/react/screens/App/Overview/helpers.js
@@ -1,0 +1,16 @@
+import getMostRecentRequest from '../common/getMostRecentRequest';
+
+export const planTransmutation = (plans = [], mappings = []) =>
+  plans.map(plan => {
+    const infraMappingName = mappings.find(
+      mapping => mapping.id === plan.options.config_info.transformation_mapping_id
+    );
+    const request = getMostRecentRequest(plan.miq_requests);
+    return {
+      ...plan,
+      infraMappingName: infraMappingName ? infraMappingName.name : null,
+      status: request ? request.status : null,
+      configVmLength: plan.options.config_info.actions.length,
+      scheduleTime: plan.schedules ? new Date(plan.schedules[0].run_at.start_time).getTime() : null
+    };
+  });


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1610390

Ensures inframappingname shows up on archived plans

### Name shows up everywhere its supposed to
<img width="1423" alt="screen shot 2018-08-08 at 2 12 37 pm" src="https://user-images.githubusercontent.com/6640236/43856056-6d0b51be-9b15-11e8-8e69-2799f0ae8e1e.png">
<img width="1424" alt="screen shot 2018-08-08 at 2 12 28 pm" src="https://user-images.githubusercontent.com/6640236/43856057-6d18d67c-9b15-11e8-9962-14ae8cd8ecb5.png">
<img width="1424" alt="screen shot 2018-08-08 at 2 12 18 pm" src="https://user-images.githubusercontent.com/6640236/43856058-6d2b4046-9b15-11e8-8afc-6665d14c7970.png">


### When mapping is deleted, we get da warning
<img width="1425" alt="screen shot 2018-08-08 at 2 13 06 pm" src="https://user-images.githubusercontent.com/6640236/43856048-66ef36d8-9b15-11e8-90fe-e88c850b8b30.png">
<img width="1426" alt="screen shot 2018-08-08 at 2 13 22 pm" src="https://user-images.githubusercontent.com/6640236/43856049-6700af6c-9b15-11e8-97ba-611ca0b36bec.png">
<img width="1425" alt="screen shot 2018-08-08 at 2 13 14 pm" src="https://user-images.githubusercontent.com/6640236/43856050-67129204-9b15-11e8-9302-8daa91f6c959.png">
