### PR TITLE
Do not fetch hosts if there are no targets

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardClustersStep/MappingWizardClustersStep.js
@@ -24,14 +24,16 @@ class MappingWizardClustersStep extends React.Component {
 
     fetchSourceClustersAction(fetchSourceClustersUrl);
     fetchTargetClustersAction(fetchTargetComputeUrls[targetProvider]).then(result => {
-      const hostIDsByClusterID = result.value.data.resources.reduce(
-        (newObject, cluster) => ({
-          ...newObject,
-          [cluster.id]: cluster.hosts.map(host => host.id)
-        }),
-        {}
-      );
-      queryHostsAction(queryHostsUrl, hostIDsByClusterID);
+      if (result.length > 0) {
+        const hostIDsByClusterID = result.value.data.resources.reduce(
+          (newObject, cluster) => ({
+            ...newObject,
+            [cluster.id]: cluster.hosts.map(host => host.id)
+          }),
+          {}
+        );
+        queryHostsAction(queryHostsUrl, hostIDsByClusterID);
+      }
     });
   };
 


### PR DESCRIPTION
Fixes #560

The API call to hosts will fail if it is not provided an array of host IDs.