### PR TITLE
select initial rows on vm csv import

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStep.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/PlanWizardVMStep.js
@@ -116,6 +116,7 @@ class PlanWizardVMStep extends React.Component {
               name="selectedVms"
               component={PlanWizardVMStepTable}
               rows={combined}
+              initialSelectedRows={discoveryMode ? [] : validVmsWithSelections.map(r => r.id)}
               onCsvImportAction={csvImportAction}
               discoveryMode={discoveryMode}
               validate={[

--- a/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/components/PlanWizardVMStepTable.js
+++ b/app/javascript/react/screens/App/Overview/screens/PlanWizard/components/PlanWizardVMStep/components/PlanWizardVMStepTable.js
@@ -37,7 +37,11 @@ class PlanWizardVMStepTable extends React.Component {
   constructor(props) {
     super(props);
 
-    const { rows } = this.props;
+    const { input, rows, initialSelectedRows } = this.props;
+
+    if (initialSelectedRows.length) {
+      input.onChange(initialSelectedRows);
+    }
 
     const getSortingColumns = () => this.state.sortingColumns || {};
 
@@ -253,7 +257,7 @@ class PlanWizardVMStepTable extends React.Component {
 
       // rows and row selection state
       rows,
-      selectedRows: [],
+      selectedRows: initialSelectedRows,
 
       // pagination default states
       pagination: {
@@ -591,6 +595,7 @@ PlanWizardVMStepTable.propTypes = {
   rows: PropTypes.array,
   onCsvImportAction: PropTypes.func,
   discoveryMode: PropTypes.bool,
+  initialSelectedRows: PropTypes.array,
   input: PropTypes.shape({
     value: PropTypes.arrayOf(PropTypes.string),
     onChange: PropTypes.func
@@ -603,6 +608,7 @@ PlanWizardVMStepTable.propTypes = {
 PlanWizardVMStepTable.defaultProps = {
   rows: [],
   onCsvImportAction: noop,
-  discoveryMode: false
+  discoveryMode: false,
+  initialSelectedRows: []
 };
 export default PlanWizardVMStepTable;


### PR DESCRIPTION
fixes #558 
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1610393

Ensure next button is enabled on CSV Import when we have valid rows and the valid rows are propagated to Redux form initially.

![csv-import-gif](https://user-images.githubusercontent.com/4237045/43966157-22d9bc54-9c8f-11e8-94ba-b4b0e3ca1cf5.gif)
