### PR TITLE
[#473] Remove root node if there are no leaf nodes

### DIFF
--- a/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/NetworksStepForm.js
+++ b/app/javascript/react/screens/App/Overview/screens/MappingWizard/components/MappingWizardNetworksStep/components/NetworksStepForm/NetworksStepForm.js
@@ -254,7 +254,7 @@ class NetworksStepForm extends React.Component {
             const updatedMapping = mappingWithSourceNetworkRemoved(networksMapping, selectedNode);
             return updatedMapping ? [...updatedNetworksMappings, updatedMapping] : [...updatedNetworksMappings];
           }, []);
-          return updatedNodes
+          return updatedNodes.length > 0
             ? [...updatedNetworksStepMappings, { ...targetCluster, nodes: updatedNodes }]
             : [...updatedNetworksStepMappings];
         }, []);


### PR DESCRIPTION
Fixes #473

Since an empty array is truthy in JavaScript, we need to explicitly check that is is empty.  If so, remove the node from its root